### PR TITLE
NetBox v2.11 Upgrade and SSO Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Alternative installation instructions for NetBox using Kubernetes. The main valu
 * The netbox deployment will work with existing redis and postgresql installations, just ensure that the configurations are changed in `netbox-configmap.yaml` and `netbox-deployment.yaml`
 * Relevant places that will need to be changed are indicated by the inline comment `#changeme`
 * The manifests were tested against the following:
-    * NetBox: 2.8.5
+    * NetBox: 2.11.12
     * Postgresql: 11.6.0
     * Redis: 5.0.5
     * Kubernetes: 1.17.4
-    * Rook: 1.3.2
-    * Ceph: 15.2.1
+    * Rook: 1.4.2
+    * Ceph: 15.2.4
 
 ## Installation
 
@@ -50,6 +50,18 @@ To get NetBox up and running on a Kubernetes cluster:
 1. A PostgreSQL DB for netbox is up and running with all the necessary schema
 1. Redis caching enabled and working
 
+##  Enabling SSO (Optional)
+
+There are plugins available in NetBox in order to setup NetBox to authenticate against an SSO authentication service. In this instance, we have used the django3_auth_saml2, and netbox-plugin-auth-saml2 plugins, and this was tested against JumpCloud.
+
+1. Uncomment `REMOTE_AUTH_BACKEND: 'django3_saml2_nbplugin.backends.SAML2CustomAttrUserBackend'` in `netbox-configmap.yaml` and `PLUGINS = ['django3_saml2_nbplugin']` in `startup-configmap.yaml`, making sure to comment out the other instance of those variables
+1. Fill in `sso-saml2-configmap.yaml` with the metadata acquired from your SSO authentication source
+1. Deploy the
+
+### Verification
+
+1.
+
 ## Deploying an Ingress (Optional)
 
 This isn't necessary for just testing. If you don't want to deploy the ingress resource, you should switch the service to use a NodePort so you can access it. nginx-ingress was used as the Ingress Controller in this example
@@ -78,6 +90,13 @@ The manifests were generated against a prometheus/grafana deployment deployed vi
 
 1. Prometheus target exists and is reporting ready for all pods deployed
 1. Dashboard should report information regarding the metrics from Django backend
+
+## Upgrading from NetBox v2.8.x
+
+If the database was instantiated using a previous version of NetBox used in this repository, cable tracing will be broken when changing versions. It is necessary to run the the cable trace fix command in the NetBox container
+
+1. `kubectl exec -it -n netbox-community netbox-<id> -- bash`
+1. `./manage.py trace_paths`
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,20 @@ Alternative installation instructions for NetBox using Kubernetes. The main valu
 
 ## Notes
 
-* The netbox deployment will work with existing redis and postgresql installations, just ensure that the configurations are changed in `netbox-configmap.yaml` and `netbox-deployment.yaml`
+* The NetBox deployment will work with existing redis and postgresql installations, just ensure that the configurations are changed in `netbox-configmap.yaml` and `netbox-deployment.yaml`
 * Relevant places that will need to be changed are indicated by the inline comment `#changeme`
 * The manifests were tested against the following:
     * NetBox: 2.11.12
-    * Postgresql: 11.6.0
-    * Redis: 5.0.5
+    * Postgresql: 14.2.0
+    * Redis: 6.2.6
     * Kubernetes: 1.17.4
     * Rook: 1.4.2
     * Ceph: 15.2.4
+* LDAP configurations were tested against the following:
+    * Windows Server 2012 - Active Directory
+    * JumpCloud - Cloud Directory
+* SSO configurations were tested against the following:
+    * JumpCloud - Cloud Directory
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ There are plugins available in NetBox in order to setup NetBox to authenticate a
 1. Once logged in, confirm members of the groups described in `FLAGS_BY_GROUP` have the correct access
     * `is_active` defined group members only are allowed to navigate the regular NetBox interface. Specific available actions are determined by individual user and group permissions defined in NetBox permissions
     * `is_staff` defined group members are allowed to navigate the NetBox Administration menu. Specific available actions are determined by individual user and group permissions defined in NetBox permissions
-    * `is_superuser` defined group members should is given full read/write admin permissions across this NetBox deployment regardless of individual user and group permissions defined in NetBox permissions
+    * `is_superuser` defined group members are given full read/write admin permissions across this NetBox deployment regardless of individual user and group permissions defined in NetBox permissions
 
 ## Deploying Metrics (Optional)
 

--- a/netbox-configmap.yaml
+++ b/netbox-configmap.yaml
@@ -23,6 +23,7 @@ data:
   METRICS_ENABLED: "true"
   NETBOX_USERNAME: guest
   REDIS_HOST: netbox-community-redis-master
+  REDIS_CACHE_HOST: netbox-community-redis-master
   REDIS_PORT: "6379"
   REDIS_CACHE_PORT: "6379"
   REDIS_DATABASE: "0"

--- a/netbox-configmap.yaml
+++ b/netbox-configmap.yaml
@@ -9,7 +9,7 @@ data:
   #changeme
   ALLOWED_HOSTS: '*'
   CHANGELOG_RETENTION: "90"
-  DB_HOST: netbox-community-postgresql
+  DB_HOST: netbox-postgresql
   DB_NAME: netbox
   DB_USER: netbox
   EMAIL_FROM: netbox@bar.com
@@ -22,8 +22,8 @@ data:
   MEDIA_ROOT: /opt/netbox/netbox/media
   METRICS_ENABLED: "true"
   NETBOX_USERNAME: guest
-  REDIS_HOST: netbox-community-redis-master
-  REDIS_CACHE_HOST: netbox-community-redis-master
+  REDIS_HOST: netbox-redis-master
+  REDIS_CACHE_HOST: netbox-redis-master
   REDIS_PORT: "6379"
   REDIS_CACHE_PORT: "6379"
   REDIS_DATABASE: "0"
@@ -64,7 +64,7 @@ data:
     # Uncomment line below if using TLS
     #AUTH_LDAP_START_TLS = True
 
-    # Service user credentials. This accout will be making all the queries when users attempt to log in
+    # Service user credentials. This account will be making all the queries when users attempt to log in
     AUTH_LDAP_BIND_DN = "<LDAP_bind_DN>" #changeme
     AUTH_LDAP_BIND_PASSWORD = read_secret('auth_ldap_bind_password')
     LDAP_IGNORE_CERT_ERRORS = True
@@ -78,6 +78,7 @@ data:
     AUTH_LDAP_USER_ATTR_MAP = {
         "first_name": "givenName",
         "last_name": "sn",
+        "username": "uid",
         "email": "mail"
     }
 
@@ -87,12 +88,17 @@ data:
     #AUTH_LDAP_GROUP_TYPE = NestedGroupOfNamesType()
     AUTH_LDAP_GROUP_TYPE = GroupOfNamesType()
 
+    # Groups defined in LDAP source and described here will be assigned the following permissions
     AUTH_LDAP_USER_FLAGS_BY_GROUP = {
+      # Allowed to navigate regular NetBox interface. Specific available actions are determined by individual user and group permissions
       "is_active": ["<LDAP_group>"], #changeme
+      # Allowed to navigate NetBox Administration menu. Specific available actions are determined by individual user and group permissions
       "is_staff": ["<LDAP_group>"], #changeme
+      # Is given full admin permissions across this NetBox deployment, regardless of individual user or group permissions
       "is_superuser": ["<LDAP_group>"], #changeme
     }
 
+    # Groups defined in LDAP source and described here will be created within NetBox Authentication
     AUTH_LDAP_MIRROR_GROUPS = {"<LDAP_groups_to_mirror>"} #changeme
 
     AUTH_LDAP_FIND_GROUP_PERMS = True

--- a/netbox-configmap.yaml
+++ b/netbox-configmap.yaml
@@ -19,6 +19,7 @@ data:
   EMAIL_USERNAME: foo
   EXEMPT_VIEW_PERMISSIONS: ''
   LOGIN_REQUIRED: "true"
+  MEDIA_ROOT: /opt/netbox/netbox/media
   METRICS_ENABLED: "true"
   NETBOX_USERNAME: guest
   REDIS_HOST: netbox-community-redis-master
@@ -28,40 +29,16 @@ data:
   REDIS_CACHE_DATABASE: "1"
   SUPERUSER_EMAIL: admin@example.com
   SUPERUSER_NAME: admin
-
-  # ngin.conf
-  # client_max_body_size used to increase limit on attachement sizes
-  nginx.conf: |
-    worker_processes 1;
-    events {
-        worker_connections  1024;
-    }
-    http {
-        include       /etc/nginx/mime.types;
-        default_type  application/octet-stream;
-        sendfile        on;
-        tcp_nopush     on;
-        keepalive_timeout  65;
-        gzip  on;
-        server_tokens off;
-        server {
-            client_max_body_size 10M;
-            listen 80;
-            server_name 127.0.0.1;
-            access_log off;
-            location /static/ {
-                expires 30d;
-                alias /opt/netbox/netbox/static/;
-            }
-            location / {
-                proxy_pass http://127.0.0.1:8001;
-                proxy_set_header X-Forwarded-Host $http_host;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header X-Forwarded-Proto $scheme;
-                add_header P3P 'CP="ALL DSP COR PSAa PSDa OUR NOR ONL UNI COM NAV"';
-            }
-        }
-    }
+  MAINTENANCE_MODE: 'False'
+  DEBUG: 'False'
+  REMOTE_AUTH_ENABLED: 'True'
+  REMOTE_AUTH_AUTO_CREATE_USER: 'True'
+  # Regular LDAP Backend
+  REMOTE_AUTH_BACKEND: netbox.authentication.LDAPBackend
+  # SSO Enabled Backend
+  #REMOTE_AUTH_BACKEND: 'django3_saml2_nbplugin.backends.SAML2CustomAttrUserBackend'
+  REMOTE_AUTH_HEADER: 'HTTP_REMOTE_USER'
+  REMOTE_AUTH_DEFAULT_GROUPS: 'sso-default-user' #changeme
 
   # LDAP configuration against Microsoft Acive Directory
   # For more information around LDAP, see https://netbox.readthedocs.io/en/stable/installation/4-ldap/
@@ -79,11 +56,12 @@ data:
             with f:
                 return f.readline().strip()
 
-    AUTH_LDAP_SERVER_URI = "<LDAP_server_URI" #changeme
+    AUTH_LDAP_SERVER_URI = "<LDAP_server_URI>" #changeme
     AUTH_LDAP_CONNECTION_OPTIONS = {
       ldap.OPT_REFERRALS: 0
     }
-    AUTH_LDAP_START_TLS = True
+    # Uncomment line below if using TLS
+    #AUTH_LDAP_START_TLS = True
 
     # Service user credentials. This accout will be making all the queries when users attempt to log in
     AUTH_LDAP_BIND_DN = "<LDAP_bind_DN>" #changeme
@@ -104,7 +82,9 @@ data:
 
     AUTH_LDAP_GROUP_SEARCH = LDAPSearch("<LDAP_group_search>") #changeme
 
-    AUTH_LDAP_GROUP_TYPE = NestedGroupOfNamesType()
+    # Choose type applicable to your LDAP
+    #AUTH_LDAP_GROUP_TYPE = NestedGroupOfNamesType()
+    AUTH_LDAP_GROUP_TYPE = GroupOfNamesType()
 
     AUTH_LDAP_USER_FLAGS_BY_GROUP = {
       "is_active": ["<LDAP_group>"], #changeme
@@ -115,5 +95,5 @@ data:
     AUTH_LDAP_MIRROR_GROUPS = {"<LDAP_groups_to_mirror>"} #changeme
 
     AUTH_LDAP_FIND_GROUP_PERMS = True
-    AUTH_LDAP_CACHE_GROUPS = False
+    #AUTH_LDAP_CACHE_GROUPS = False
     AUTH_LDAP_GROUP_CACHE_TIMEOUT = 3600

--- a/netbox-deployment.yaml
+++ b/netbox-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: netbox
@@ -18,109 +18,29 @@ spec:
       containers:
       # NetBox container using the netbox-docker image: https://github.com/netbox-community/netbox-docker
       - name: netbox
-        image: netboxcommunity/netbox:v2.8.5-ldap
+        image: quay.io/netboxcommunity/netbox:v2.11.12-ldap
         ports:
         - name: http
-          containerPort: 80
-        readinessProbe: # will mark the pod as ready once the initialization script is completed and will probe every 5 seconds
+          containerPort: 8080
+        readinessProbe: # will mark the pod as ready once the initialization script is completed and will probe every 20 seconds
           httpGet:
             path: /
             port: http
           initialDelaySeconds: 5
-          periodSeconds: 5
-        env:
-        # More configuration can be added via: https://netbox.readthedocs.io/en/stable/configuration/optional-settings/
-        - name: ALLOWED_HOSTS
-          valueFrom:
-            configMapKeyRef:
-              key: ALLOWED_HOSTS
+          periodSeconds: 20
+        envFrom:
+          - configMapRef:
               name: netbox-configmap
-        - name: CHANGELOG_RETENTION
-          valueFrom:
-            configMapKeyRef:
-              key: CHANGELOG_RETENTION
-              name: netbox-configmap
-        - name: DB_HOST
-          valueFrom:
-            configMapKeyRef:
-              key: DB_HOST
-              name: netbox-configmap
-        - name: DB_NAME
-          valueFrom:
-            configMapKeyRef:
-              key: DB_NAME
-              name: netbox-configmap
-        - name: DB_USER
-          valueFrom:
-            configMapKeyRef:
-              key: DB_USER
-              name: netbox-configmap
-        - name: EMAIL_FROM
-          valueFrom:
-            configMapKeyRef:
-              key: EMAIL_FROM
-              name: netbox-configmap
-        - name: EMAIL_PORT
-          valueFrom:
-            configMapKeyRef:
-              key: EMAIL_PORT
-              name: netbox-configmap
-        - name: EMAIL_SERVER
-          valueFrom:
-            configMapKeyRef:
-              key: EMAIL_SERVER
-              name: netbox-configmap
-        - name: EMAIL_TIMEOUT
-          valueFrom:
-            configMapKeyRef:
-              key: EMAIL_TIMEOUT
-              name: netbox-configmap
-        - name: EMAIL_USERNAME
-          valueFrom:
-            configMapKeyRef:
-              key: EMAIL_USERNAME
-              name: netbox-configmap
-        - name: EXEMPT_VIEW_PERMISSIONS
-          valueFrom:
-            configMapKeyRef:
-              key: EXEMPT_VIEW_PERMISSIONS
-              name: netbox-configmap
-        - name: LOGIN_REQUIRED
-          valueFrom:
-            configMapKeyRef:
-              key: LOGIN_REQUIRED
-              name: netbox-configmap
-        - name: METRICS_ENABLED
-          valueFrom:
-            configMapKeyRef:
-              key: METRICS_ENABLED
-              name: netbox-configmap
-        - name: NETBOX_USERNAME
-          valueFrom:
-            configMapKeyRef:
-              key: NETBOX_USERNAME
-              name: netbox-configmap
-        - name: REDIS_HOST
-          valueFrom:
-            configMapKeyRef:
-              key: REDIS_HOST
-              name: netbox-configmap
-        - name: REDIS_CACHE_HOST
-          valueFrom:
-            configMapKeyRef:
-              key: REDIS_CACHE_HOST
-              name: netbox-configmap
-        - name: REDIS_PORT
-          valueFrom:
-            configMapKeyRef:
-              key: REDIS_PORT
-              name: netbox-configmap
-        - name: REDIS_CACHE_PORT
-          valueFrom:
-            configMapKeyRef:
-              key: REDIS_CACHE_PORT
-              name: netbox-configmap
-
+        lifecycle: # Will run the post-startup scripts detailed in netbox-startup-configmap.yaml
+          postStart:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - >
+                  bash /home/install-plugins.sh &&
+                  bash /home/start-rqworker.sh &&
+                  bash /home/nginx-caching-fix.sh
         volumeMounts:
         # Mounting secrets for netbox and other related components
         - name: auth-ldap-bind-password
@@ -153,37 +73,70 @@ spec:
           mountPath: /run/secrets/superuser_password
           subPath: superuser_password
           readOnly: true
-
         # Persistent Volume paths
-        - name: netbox-static-files # Shared directory with the nginx container for static files
-          mountPath: /opt/netbox/netbox/static
         - name: netbox-media-files # Allows for multiple replicas of the netbox pod to be available
-          mountPath: /etc/netbox/media
+          mountPath: /opt/netbox/netbox/media
         - name: ldap-config # Allows for LDAP authentication to work
           subPath: ldap_config.py
           mountPath: /opt/netbox/netbox/netbox/ldap_config.py
-
-      # nginx sidecar container used to serve static files
-      - name: nginx
-        image: nginx:1.17.3-alpine
-        volumeMounts:
-        - name: netbox-static-files
-          mountPath: /opt/netbox/netbox/static
-        - name: netbox-nginx-config
-          subPath: nginx.conf
-          mountPath: /etc/nginx/nginx.conf
-
+        - mountPath: /etc/netbox/config/netbox-plugins.py
+          name: netbox-plugins
+          subPath: netbox-plugins.py
+        - mountPath: /home/install-plugins.sh
+          name: install-plugins
+          subPath: install-plugins.sh
+        - mountPath: /home/start-rqworker.sh
+          name: start-rqworker
+          subPath: start-rqworker.sh
+        - mountPath: /home/nginx-caching-fix.sh
+          name: nginx-caching-fix
+          subPath: nginx-caching-fix.sh
+        - name: sso-saml2-xml
+          mountPath: /opt/netbox/sso-saml2.xml
+          subPath: sso-saml2-metadata.xml
       restartPolicy: Always
-
       volumes:
-      # Secret volumes
-      - name: netbox-secret # contains most netbox secrets that would be used
-        secret:
-          secretName: netbox-secret
-      - name: netbox-redis # contains the password used for redis caching
-        secret:
-          secretName: netbox-redis
-
+      # Reference to configmaps and PVs
+      - name: netbox-media-files
+        persistentVolumeClaim:
+          claimName: netbox-media-pvc
+          readOnly: false
+      - name: ldap-config
+        configMap:
+          name: netbox-configmap
+          items:
+            - key: ldap_config.py
+              path: ldap_config.py
+      - name: netbox-plugins
+        configMap:
+          name: startup-configmap
+          items:
+          - key: "netbox-plugins.py"
+            path: "netbox-plugins.py"
+      - name: install-plugins
+        configMap:
+          name: startup-configmap
+          items:
+          - key: "install-plugins.sh"
+            path: "install-plugins.sh"
+      - name: start-rqworker
+        configMap:
+          name: startup-configmap
+          items:
+          - key: "start-rqworker.sh"
+            path: "start-rqworker.sh"
+      - name: nginx-caching-fix
+        configMap:
+          name: startup-configmap
+          items:
+          - key: "nginx-caching-fix.sh"
+            path: "nginx-caching-fix.sh"
+      - name: sso-saml2-xml
+        configMap:
+          name: sso-saml2-xml
+          items:
+            - key: sso-saml2-metadata.xml
+              path: sso-saml2-metadata.xml
       # Populate via secret
       - name: auth-ldap-bind-password
         secret:
@@ -233,23 +186,3 @@ spec:
           items:
           - key: superuser_api_token
             path: superuser_api_token
-
-      # Reference to configmaps and PVs
-      - name: ldap-config
-        configMap:
-          name: netbox-configmap
-          items:
-            - key: ldap_config.py
-              path: ldap_config.py
-      - name: netbox-nginx-config
-        configMap:
-          name: netbox-configmap
-          items:
-            - key: nginx.conf
-              path: nginx.conf
-      - name: netbox-static-files
-        emptyDir: {}
-      - name: netbox-media-files
-        persistentVolumeClaim:
-          claimName: netbox-media-pvc
-          readOnly: false

--- a/netbox-deployment.yaml
+++ b/netbox-deployment.yaml
@@ -146,9 +146,9 @@ spec:
             path: auth_ldap_bind_password
       - name: db-password
         secret:
-          secretName: netbox-community-postgresql
+          secretName: netbox-postgresql
           items:
-          - key: postgresql-password
+          - key: password
             path: db_password
       - name: email-password
         secret:

--- a/netbox-monitoring.yaml
+++ b/netbox-monitoring.yaml
@@ -10,7 +10,7 @@ spec:
   - name: metrics
     port: 80
     protocol: TCP
-    targetPort: 80
+    targetPort: 8080
   selector:
     k8s-app: netbox
 ---

--- a/netbox-secrets.yaml
+++ b/netbox-secrets.yaml
@@ -6,6 +6,7 @@ metadata:
 type: Opaque
 data:
   # These SHOULD be replaced with any other base64 encoded values
+  ## echo <password> | base64
   # Note that the mysql and redis passwords are being pulled from different secrets deployed in the same namespaces
   #changeme
   auth_ldap_bind_password: Cg==

--- a/netbox-service.yaml
+++ b/netbox-service.yaml
@@ -7,9 +7,7 @@ metadata:
     k8s-app: netbox
 spec:
   ports:
-  - name: http
-    port: 80
+  - port: 80
     targetPort: http
   selector:
     k8s-app: netbox
-  type: ClusterIP

--- a/netbox-startup-configmap.yaml
+++ b/netbox-startup-configmap.yaml
@@ -14,10 +14,12 @@ data:
     PLUGINS_CONFIG = {
         'django3_saml2_nbplugin': {
 
-            # Use the Netbox default remote backend
+            # Use the NetBox default remote backend
             # 'AUTHENTICATION_BACKEND': 'netbox.authentication.RemoteUserBackend',
-            'AUTHENTICATION_BACKEND': 'django3_saml2_nbplugin.backends.SAML2CustomAttrUserBackend',
+            # Use the NetBox LDAP backend, default configs
             # 'AUTHENTICATION_BACKEND': 'django3_saml2_nbplugin.backends.SAML2AttrUserBackend',
+            # Use the NetBox LDAP backend, configs defined below
+            'AUTHENTICATION_BACKEND': 'django3_saml2_nbplugin.backends.SAML2CustomAttrUserBackend',
 
             # Custom URL to validate incoming SAML requests against
             'ASSERTION_URL': 'https://netbox.company.ca', #changeme
@@ -53,12 +55,13 @@ data:
                 'GROUP_ATTR': 'memberOf',
                 # Dict of user flags to groups.
                 # If the user is in the group then the flag will be set to True. Optional.
-                # Used as an override to the same variable set in ldap_config.py in netbox-configmap. It is commented out since it is unnecessary to have the already set configurations overrided.
-                #'FLAGS_BY_GROUP': {
-                #    'is_active': 'SSO_ACTIVE_GROUP',
-                #    'is_staff': 'SSO_STAFF_GROUP',
-                #    'is_superuser': 'SSO_SUPERUSER_GROUP'
-                #},
+                # Used as an override to the same variable set in ldap_config.py in netbox-configmap
+                # It is recommended to fill these in as the same configurations from netbox-configmap.yaml function inconsistently when SSO is enabled
+                'FLAGS_BY_GROUP': {
+                    'is_active': 'SSO_ACTIVE_GROUP', #changeme
+                    'is_staff': 'SSO_STAFF_GROUP', #changeme
+                    'is_superuser': 'SSO_SUPERUSER_GROUP' #hangeme
+                },
                 # Dict of SAML groups to NetBox groups. Optional.
                 # Groups must be created beforehand in NetBox.
                 # Used to populate NetBox defined user groups (right) with members of groups in the SSO source (left). Not necessary if NetBox groups and members are already defined in the SSO source

--- a/postgresql-values.yaml
+++ b/postgresql-values.yaml
@@ -1,222 +1,203 @@
-## Global Docker image parameters
-## Please, note that this will override the image parameters, including dependencies, configured to use the global value
-## Current available global Docker image parameters: imageRegistry and imagePullSecrets
+## @section Global parameters
+## Please, note that this will override the parameters, including dependencies, configured to use the global value
 ##
 global:
-  postgresql: {}
-#   imageRegistry: myRegistryName
-#   imagePullSecrets:
-#     - myRegistryKeySecretName
-#   storageClass: myStorageClass
+  ## @param global.imageRegistry Global Docker image registry
+  ##
+  imageRegistry: ""
+  ## @param global.imagePullSecrets Global Docker registry secret names as an array
+  ## e.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
+  ## @param global.storageClass Global StorageClass for Persistent Volume(s)
+  ##
+  storageClass: ""
+  postgresql:
+    ## @param global.postgresql.auth.postgresPassword Password for the "postgres" admin user (overrides `auth.postgresPassword`)
+    ## @param global.postgresql.auth.username Name for a custom user to create (overrides `auth.username`)
+    ## @param global.postgresql.auth.password Password for the custom user to create (overrides `auth.password`)
+    ## @param global.postgresql.auth.database Name for a custom database to create (overrides `auth.database`)
+    ## @param global.postgresql.auth.existingSecret Name of existing secret to use for PostgreSQL credentials (overrides `auth.existingSecret`)
+    ##
+    auth:
+      postgresPassword: ""
+      username: ""
+      password: ""
+      database: ""
+      existingSecret: ""
+    ## @param global.postgresql.service.ports.postgresql PostgreSQL service port (overrides `service.ports.postgresql`)
+    ##
+    service:
+      ports:
+        postgresql: ""
+
+## @section Common parameters
+##
+
+## @param kubeVersion Override Kubernetes version
+##
+kubeVersion: ""
+## @param nameOverride String to partially override common.names.fullname template (will maintain the release name)
+##
+nameOverride: ""
+## @param fullnameOverride String to fully override common.names.fullname template
+##
+fullnameOverride: ""
+## @param clusterDomain Kubernetes Cluster Domain
+##
+clusterDomain: cluster.local #changeme
+## @param extraDeploy Array of extra objects to deploy with the release (evaluated as a template)
+##
+extraDeploy: []
+## @param commonLabels Add labels to all the deployed resources
+##
+commonLabels: {}
+## @param commonAnnotations Add annotations to all the deployed resources
+##
+commonAnnotations: {}
+## Enable diagnostic mode in the statefulset
+##
+diagnosticMode:
+  ## @param diagnosticMode.enabled Enable diagnostic mode (all probes will be disabled and the command will be overridden)
+  ##
+  enabled: false
+  ## @param diagnosticMode.command Command to override all containers in the statefulset
+  ##
+  command:
+    - sleep
+  ## @param diagnosticMode.args Args to override all containers in the statefulset
+  ##
+  args:
+    - infinity
+
+## @section PostgreSQL common parameters
+##
 
 ## Bitnami PostgreSQL image version
 ## ref: https://hub.docker.com/r/bitnami/postgresql/tags/
+## @param image.registry PostgreSQL image registry
+## @param image.repository PostgreSQL image repository
+## @param image.tag PostgreSQL image tag (immutable tags are recommended)
+## @param image.pullPolicy PostgreSQL image pull policy
+## @param image.pullSecrets Specify image pull secrets
+## @param image.debug Specify if debug values should be set
 ##
 image:
   registry: docker.io
   repository: bitnami/postgresql
-  tag: 11.6.0-debian-10-r5
+  tag: 14.2.0-debian-10-r14
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## Example:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
   ##
-  # pullSecrets:
-  #   - myRegistryKeySecretName
-
+  pullSecrets: []
   ## Set to true if you would like to see extra information on logs
-  ## It turns BASH and NAMI debugging in minideb
-  ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-bash-debugging
+  ##
   debug: false
-
-## String to partially override postgresql.fullname template (will maintain the release name)
-##
-# nameOverride:
-
-## String to fully override postgresql.fullname template
-##
-# fullnameOverride:
-
-##
-## Init containers parameters:
-## volumePermissions: Change the owner of the persist volume mountpoint to RunAsUser:fsGroup
-##
-volumePermissions:
-  enabled: true
-  image:
-    registry: docker.io
-    repository: bitnami/minideb
-    tag: buster
-    ## Specify a imagePullPolicy
-    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-    ##
-    pullPolicy: Always
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ##
-    # pullSecrets:
-    #   - myRegistryKeySecretName
-  ## Init container Security Context
-  ## Note: the chown of the data folder is done to securityContext.runAsUser
-  ## and not the below volumePermissions.securityContext.runAsUser
-  ## When runAsUser is set to special value "auto", init container will try to chwon the
-  ## data folder to autodetermined user&group, using commands: `id -u`:`id -G | cut -d" " -f2`
-  ## "auto" is especially useful for OpenShift which has scc with dynamic userids (and 0 is not allowed).
-  ## You may want to use this volumePermissions.securityContext.runAsUser="auto" in combination with
-  ## pod securityContext.enabled=false and shmVolume.chmod.enabled=false .
-  securityContext:
-    runAsUser: 0
-
-## Use an alternate scheduler, e.g. "stork".
-## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
-##
-# schedulerName:
-
-## Pod Security Context
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-##
-securityContext:
-  enabled: true
-  fsGroup: 1001
-  runAsUser: 1001
-
-## Pod Service Account
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-serviceAccount:
-  enabled: false
-  ## Name of an already existing service account. Setting this value disables the automatic service account creation.
-  # name:
-
-replication:
-  enabled: false
-  user: repl_user
-  password: repl_password
-  slaveReplicas: 1
-  ## Set synchronous commit mode: on, off, remote_apply, remote_write and local
-  ## ref: https://www.postgresql.org/docs/9.6/runtime-config-wal.html#GUC-WAL-LEVEL
-  synchronousCommit: "off"
-  ## From the number of `slaveReplicas` defined above, set the number of those that will have synchronous replication
-  ## NOTE: It cannot be > slaveReplicas
-  numSynchronousReplicas: 0
-  ## Replication Cluster application name. Useful for defining multiple replication policies
-  applicationName: my_application
-
-## PostgreSQL admin password (used when `postgresqlUsername` is not `postgres`)
-## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-user-on-first-run (see note!)
-# postgresqlPostgresPassword:
-
-## PostgreSQL user (has superuser privileges if username is `postgres`)
+## Authentication parameters
 ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#setting-the-root-password-on-first-run
-postgresqlUsername: netbox
-
-## PostgreSQL password
-## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#setting-the-root-password-on-first-run
-##
-# postgresqlPassword:
-
-## PostgreSQL password using existing secret
-## existingSecret: secret
-
-## Mount PostgreSQL secret as a file instead of passing environment variable
-# usePasswordFile: false
-
-## Create a database
 ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-on-first-run
+## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-user-on-first-run
 ##
-postgresqlDatabase: netbox
-
-## PostgreSQL data dir
-## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md
+auth:
+  ## @param auth.enablePostgresUser Assign a password to the "postgres" admin user. Otherwise, remote access will be blocked for this user
+  ##
+  enablePostgresUser: true
+  ## @param auth.postgresPassword Password for the "postgres" admin user
+  ##
+  postgresPassword: ""
+  ## @param auth.username Name for a custom user to create
+  ##
+  username: "netbox"
+  ## @param auth.password Password for the custom user to create
+  ##
+  password: ""
+  ## @param auth.database Name for a custom database to create
+  ##
+  database: "netbox"
+  ## @param auth.replicationUsername Name of the replication user
+  ##
+  replicationUsername: repl_user
+  ## @param auth.replicationPassword Password for the replication user
+  ##
+  replicationPassword: ""
+  ## @param auth.existingSecret Name of existing secret to use for PostgreSQL credentials
+  ## `auth.postgresPassword`, `auth.password`, and `auth.replicationPassword` will be ignored and picked up from this secret
+  ## The secret must contain the keys `postgres-password` (which is the password for "postgres" admin user),
+  ## `password` (which is the password for the custom user to create when `auth.username` is set),
+  ## and `replication-password` (which is the password for replication user).
+  ## The secret might also contains the key `ldap-password` if LDAP is enabled. `ldap.bind_password` will be ignored and
+  ## picked from this secret in this case.
+  ## The value is evaluated as a template.
+  ##
+  existingSecret: ""
+  ## @param auth.usePasswordFiles Mount credentials as a files instead of using an environment variable
+  ##
+  usePasswordFiles: false
+## @param architecture PostgreSQL architecture (`standalone` or `replication`)
 ##
-postgresqlDataDir: /bitnami/postgresql/data
-
-## An array to add extra environment variables
-## For example:
-## extraEnv:
-##   - name: FOO
-##     value: "bar"
+architecture: standalone
+## Replication configuration
+## Ignored if `architecture` is `standalone`
 ##
-# extraEnv:
-extraEnv: []
-
-## Name of a ConfigMap containing extra env vars
+replication:
+  ## @param replication.synchronousCommit Set synchronous commit mode. Allowed values: `on`, `remote_apply`, `remote_write`, `local` and `off`
+  ## @param replication.numSynchronousReplicas Number of replicas that will have synchronous replication. Note: Cannot be greater than `readReplicas.replicaCount`.
+  ## ref: https://www.postgresql.org/docs/current/runtime-config-wal.html#GUC-SYNCHRONOUS-COMMIT
+  ##
+  synchronousCommit: "off"
+  numSynchronousReplicas: 0
+  ## @param replication.applicationName Cluster application name. Useful for advanced replication settings
+  ##
+  applicationName: my_application
+## @param containerPorts.postgresql PostgreSQL container port
 ##
-# extraEnvVarsCM:
-
-## Specify extra initdb args
-## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md
+containerPorts:
+  postgresql: 5432
+## Audit settings
+## https://github.com/bitnami/bitnami-docker-postgresql#auditing
+## @param audit.logHostname Log client hostnames
+## @param audit.logConnections Add client log-in operations to the log file
+## @param audit.logDisconnections Add client log-outs operations to the log file
+## @param audit.pgAuditLog Add operations to log using the pgAudit extension
+## @param audit.pgAuditLogCatalog Log catalog using pgAudit
+## @param audit.clientMinMessages Message log level to share with the user
+## @param audit.logLinePrefix Template for log line prefix (default if not set)
+## @param audit.logTimezone Timezone for the log timestamps
 ##
-# postgresqlInitdbArgs:
-
-## Specify a custom location for the PostgreSQL transaction log
-## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md
-##
-# postgresqlInitdbWalDir:
-
-## PostgreSQL configuration
-## Specify runtime configuration parameters as a dict, using camelCase, e.g.
-## {"sharedBuffers": "500MB"}
-## Alternatively, you can put your postgresql.conf under the files/ directory
-## ref: https://www.postgresql.org/docs/current/static/runtime-config.html
-##
-# postgresqlConfiguration:
-
-## PostgreSQL extended configuration
-## As above, but _appended_ to the main configuration
-## Alternatively, you can put your *.conf under the files/conf.d/ directory
-## https://github.com/bitnami/bitnami-docker-postgresql#allow-settings-to-be-loaded-from-files-other-than-the-default-postgresqlconf
-##
-# postgresqlExtendedConf:
-
-## PostgreSQL client authentication configuration
-## Specify content for pg_hba.conf
-## Default: do not create pg_hba.conf
-## Alternatively, you can put your pg_hba.conf under the files/ directory
-# pgHbaConfiguration: |-
-#   local all all trust
-#   host all all localhost trust
-#   host mydatabase mysuser 192.168.0.0/24 md5
-
-## ConfigMap with PostgreSQL configuration
-## NOTE: This will override postgresqlConfiguration and pgHbaConfiguration
-# configurationConfigMap:
-
-## ConfigMap with PostgreSQL extended configuration
-# extendedConfConfigMap:
-
-## initdb scripts
-## Specify dictionary of scripts to be run at first boot
-## Alternatively, you can put your scripts under the files/docker-entrypoint-initdb.d directory
-##
-# initdbScripts:
-#   my_init_script.sh: |
-#      #!/bin/sh
-#      echo "Do something."
-
-## ConfigMap with scripts to be run at first boot
-## NOTE: This will override initdbScripts
-# initdbScriptsConfigMap:
-
-## Secret with scripts to be run at first boot (in case it contains sensitive information)
-## NOTE: This can work along initdbScripts or initdbScriptsConfigMap
-# initdbScriptsSecret:
-
-## Specify the PostgreSQL username and password to execute the initdb scripts
-# initdbUser:
-# initdbPassword:
-
-## Optional duration in seconds the pod needs to terminate gracefully.
-## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
-##
-# terminationGracePeriodSeconds: 30
-
+audit:
+  logHostname: false
+  logConnections: false
+  logDisconnections: false
+  pgAuditLog: ""
+  pgAuditLogCatalog: "off"
+  clientMinMessages: error
+  logLinePrefix: ""
+  logTimezone: ""
 ## LDAP configuration
+## @param ldap.enabled Enable LDAP support
+## @param ldap.url LDAP URL beginning in the form `ldap[s]://host[:port]/basedn`
+## @param ldap.server IP address or name of the LDAP server.
+## @param ldap.port Port number on the LDAP server to connect to
+## @param ldap.prefix String to prepend to the user name when forming the DN to bind
+## @param ldap.suffix String to append to the user name when forming the DN to bind
+## @param ldap.baseDN Root DN to begin the search for the user in
+## @param ldap.bindDN DN of user to bind to LDAP
+## @param ldap.bind_password Password for the user to bind to LDAP
+## @param ldap.search_attr Attribute to match against the user name in the search
+## @param ldap.search_filter The search filter to use when doing search+bind authentication
+## @param ldap.scheme Set to `ldaps` to use LDAPS
+## @param ldap.tls Set to `1` to use TLS encryption
 ##
 ldap:
   enabled: false
@@ -227,268 +208,176 @@ ldap:
   suffix: ""
   baseDN: ""
   bindDN: ""
-  bind_password:
+  bind_password: ""
   search_attr: ""
   search_filter: ""
   scheme: ""
-  tls: false
-
-## PostgreSQL service configuration
-service:
-  ## PosgresSQL service type
-  type: ClusterIP
-  # clusterIP: None
-  port: 5432
-
-  ## Specify the nodePort value for the LoadBalancer and NodePort service types.
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
-  ##
-  # nodePort:
-
-  ## Provide any additional annotations which may be required.
-  ## The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart
-  annotations: {}
-  ## Set the LoadBalancer service type to internal only.
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
-  ##
-  # loadBalancerIP:
-
-  ## Load Balancer sources
-  ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
-  ##
-  # loadBalancerSourceRanges:
-  # - 10.10.10.0/24
-
-## Start master and slave(s) pod(s) without limitations on shm memory.
-## By default docker and containerd (and possibly other container runtimes)
-## limit `/dev/shm` to `64M` (see e.g. the
-## [docker issue](https://github.com/docker-library/postgres/issues/416) and the
-## [containerd issue](https://github.com/containerd/containerd/issues/3654),
-## which could be not enough if PostgreSQL uses parallel workers heavily.
-## If this option is present and value is `true`,
-## to the target database pod will be mounted a new tmpfs volume to remove
-## this limitation.
-## If chmod.enabled is `true`, init container will chmod 777 `/dev/shm`.
+  tls: ""
+## @param postgresqlDataDir PostgreSQL data dir folder
+##
+postgresqlDataDir: /bitnami/postgresql/data
+## @param postgresqlSharedPreloadLibraries Shared preload libraries (comma-separated list)
+##
+postgresqlSharedPreloadLibraries: "pgaudit"
+## Start PostgreSQL pod(s) without limitations on shm memory.
+## By default docker and containerd (and possibly other container runtimes) limit `/dev/shm` to `64M`
+## ref: https://github.com/docker-library/postgres/issues/416
+## ref: https://github.com/containerd/containerd/issues/3654
+##
 shmVolume:
+  ## @param shmVolume.enabled Enable emptyDir volume for /dev/shm for PostgreSQL pod(s)
+  ##
   enabled: true
-  chmod:
-    enabled: true
-
-## PostgreSQL data Persistent Volume Storage Class
-## If defined, storageClassName: <storageClass>
-## If set to "-", storageClassName: "", which disables dynamic provisioning
-## If undefined (the default) or set to null, no storageClassName spec is
-##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-##   GKE, AWS & OpenStack)
+  ## @param shmVolume.sizeLimit Set this to enable a size limit on the shm tmpfs
+  ## Note: the size of the tmpfs counts against container's memory limit
+  ## e.g:
+  ## sizeLimit: 1Gi
+  ##
+  sizeLimit: ""
+## TLS configuration
 ##
-persistence:
-  enabled: true
-  ## A manually managed Persistent Volume and Claim
-  ## If defined, PVC must be created manually before volume will be bound
-  ## The value is evaluated as a template, so, for example, the name can depend on .Release or .Chart
-  ##
-  # existingClaim:
-
-  ## The path the volume will be mounted at, useful when using different
-  ## PostgreSQL images.
-  ##
-  mountPath: /bitnami/postgresql
-
-  ## The subdirectory of the volume to mount to, useful in dev environments
-  ## and one PV for multiple services.
-  ##
-  subPath: ""
-
-  storageClass: "rook-ceph-block" #changeme
-  accessModes:
-    - ReadWriteOnce
-  size: 10Gi
-  annotations: {}
-
-## updateStrategy for PostgreSQL StatefulSet and its slaves StatefulSets
-## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
-updateStrategy:
-  type: RollingUpdate
-
-##
-## PostgreSQL Master parameters
-##
-master:
-  ## Node, affinity, tolerations, and priorityclass settings for pod assignment
-  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
-  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption
-  # nodeSelector: {"beta.kubernetes.io/arch": "amd64"}
-  affinity: {}
-  # tolerations: []
-  labels: {}
-  annotations: {}
-  podLabels: {}
-  podAnnotations: {}
-  priorityClassName: ""
-  extraInitContainers: |
-  # - name: do-something
-  #   image: busybox
-  #   command: ['do', 'something']
-  ## Additional PostgreSQL Master Volume mounts
-  ##
-  extraVolumeMounts: []
-  ## Additional PostgreSQL Master Volumes
-  ##
-  extraVolumes: []
-
-##
-## PostgreSQL Slave parameters
-##
-slave:
-  ## Node, affinity, tolerations, and priorityclass settings for pod assignment
-  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
-  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption
-  # nodeSelector: {"beta.kubernetes.io/arch": "amd64"}
-  affinity: {}
-  # tolerations: []
-  labels: {}
-  annotations: {}
-  podLabels: {}
-  podAnnotations: {}
-  priorityClassName: ""
-  extraInitContainers: |
-  # - name: do-something
-  #   image: busybox
-  #   command: ['do', 'something']
-  ## Additional PostgreSQL Slave Volume mounts
-  ##
-  extraVolumeMounts: []
-  ## Additional PostgreSQL Slave Volumes
-  ##
-  extraVolumes: []
-
-## Configure resource requests and limits
-## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-##
-resources:
-  requests:
-    memory: 256Mi
-    cpu: 250m
-
-networkPolicy:
-  ## Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
+tls:
+  ## @param tls.enabled Enable TLS traffic support
   ##
   enabled: false
-
-  ## The Policy model to apply. When set to false, only pods with the correct
-  ## client label will have network access to the port PostgreSQL is listening
-  ## on. When true, PostgreSQL will accept connections from any source
-  ## (with the correct destination port).
+  ## @param tls.autoGenerated Generate automatically self-signed TLS certificates
   ##
-  allowExternal: true
-
-  ## if explicitNamespacesSelector is missing or set to {}, only client Pods that are in the networkPolicy's namespace
-  ## and that match other criteria, the ones that have the good label, can reach the DB.
-  ## But sometimes, we want the DB to be accessible to clients from other namespaces, in this case, we can use this
-  ## LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added.
+  autoGenerated: false
+  ## @param tls.preferServerCiphers Whether to use the server's TLS cipher preferences rather than the client's
   ##
-  # explicitNamespacesSelector:
-    # matchLabels:
-      # role: frontend
-    # matchExpressions:
-      # - {key: role, operator: In, values: [frontend]}
+  preferServerCiphers: true
+  ## @param tls.certificatesSecret Name of an existing secret that contains the certificates
+  ##
+  certificatesSecret: ""
+  ## @param tls.certFilename Certificate filename
+  ##
+  certFilename: ""
+  ## @param tls.certKeyFilename Certificate key filename
+  ##
+  certKeyFilename: ""
+  ## @param tls.certCAFilename CA Certificate filename
+  ## If provided, PostgreSQL will authenticate TLS/SSL clients by requesting them a certificate
+  ## ref: https://www.postgresql.org/docs/9.6/auth-methods.html
+  ##
+  certCAFilename: ""
+  ## @param tls.crlFilename File containing a Certificate Revocation List
+  ##
+  crlFilename: ""
 
-## Configure extra options for liveness and readiness probes
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
-livenessProbe:
-  enabled: true
-  initialDelaySeconds: 30
-  periodSeconds: 10
-  timeoutSeconds: 5
-  failureThreshold: 6
-  successThreshold: 1
-
-readinessProbe:
-  enabled: true
-  initialDelaySeconds: 5
-  periodSeconds: 10
-  timeoutSeconds: 5
-  failureThreshold: 6
-  successThreshold: 1
-
-## Configure metrics exporter
+## @section PostgreSQL Primary parameters
 ##
-metrics:
-  enabled: false
-  # resources: {}
-  service:
-    type: ClusterIP
-    annotations:
-      prometheus.io/scrape: "true"
-      prometheus.io/port: "9187"
-    loadBalancerIP:
-  serviceMonitor:
-    enabled: false
-    additionalLabels: {}
-    # namespace: monitoring
-    # interval: 30s
-    # scrapeTimeout: 10s
-  ## Custom PrometheusRule to be defined
-  ## The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart
-  ## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
-  prometheusRule:
-    enabled: false
-    additionalLabels: {}
-    namespace: ""
-    rules: []
-      ## These are just examples rules, please adapt them to your needs.
-      ## Make sure to constraint the rules to the current postgresql service.
-      # - alert: HugeReplicationLag
-      #   expr: pg_replication_lag{service="{{ template "postgresql.fullname" . }}-metrics"} / 3600 > 1
-      #   for: 1m
-      #   labels:
-      #     severity: critical
-      #   annotations:
-      #     description: replication for {{ template "postgresql.fullname" . }} PostgreSQL is lagging by {{ "{{ $value }}" }} hour(s).
-      #     summary: PostgreSQL replication is lagging by {{ "{{ $value }}" }} hour(s).
-  image:
-    registry: docker.io
-    repository: bitnami/postgres-exporter
-    tag: 0.8.0-debian-10-r4
-    pullPolicy: IfNotPresent
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+primary:
+  ## @param primary.configuration PostgreSQL Primary main configuration to be injected as ConfigMap
+  ## ref: https://www.postgresql.org/docs/current/static/runtime-config.html
+  ##
+  configuration: ""
+  ## @param primary.pgHbaConfiguration PostgreSQL Primary client authentication configuration
+  ## ref: https://www.postgresql.org/docs/current/static/auth-pg-hba-conf.html
+  ## e.g:#
+  ## pgHbaConfiguration: |-
+  ##   local all all trust
+  ##   host all all localhost trust
+  ##   host mydatabase mysuser 192.168.0.0/24 md5
+  ##
+  pgHbaConfiguration: ""
+  ## @param primary.existingConfigmap Name of an existing ConfigMap with PostgreSQL Primary configuration
+  ## NOTE: `primary.configuration` and `primary.pgHbaConfiguration` will be ignored
+  ##
+  existingConfigmap: ""
+  ## @param primary.extendedConfiguration Extended PostgreSQL Primary configuration (appended to main or default configuration)
+  ## ref: https://github.com/bitnami/bitnami-docker-postgresql#allow-settings-to-be-loaded-from-files-other-than-the-default-postgresqlconf
+  ##
+  extendedConfiguration: ""
+  ## @param primary.existingExtendedConfigmap Name of an existing ConfigMap with PostgreSQL Primary extended configuration
+  ## NOTE: `primary.extendedConfiguration` will be ignored
+  ##
+  existingExtendedConfigmap: ""
+  ## Initdb configuration
+  ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#specifying-initdb-arguments
+  ##
+  initdb:
+    ## @param primary.initdb.args PostgreSQL initdb extra arguments
     ##
-    # pullSecrets:
-    #   - myRegistryKeySecretName
-  ## Define additional custom metrics
-  ## ref: https://github.com/wrouesnel/postgres_exporter#adding-new-metrics-via-a-config-file
-  # customMetrics:
-  #   pg_database:
-  #     query: "SELECT d.datname AS name, CASE WHEN pg_catalog.has_database_privilege(d.datname, 'CONNECT') THEN pg_catalog.pg_database_size(d.datname) ELSE 0 END AS size FROM pg_catalog.pg_database d where datname not in ('template0', 'template1', 'postgres')"
-  #     metrics:
-  #       - name:
-  #           usage: "LABEL"
-  #           description: "Name of the database"
-  #       - size_bytes:
-  #           usage: "GAUGE"
-  #           description: "Size of the database in bytes"
-  ## Pod Security Context
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+    args: ""
+    ## @param primary.initdb.postgresqlWalDir Specify a custom location for the PostgreSQL transaction log
+    ##
+    postgresqlWalDir: ""
+    ## @param primary.initdb.scripts Dictionary of initdb scripts
+    ## Specify dictionary of scripts to be run at first boot
+    ## e.g:
+    ## scripts:
+    ##   my_init_script.sh: |
+    ##      #!/bin/sh
+    ##      echo "Do something."
+    ##
+    scripts: {}
+    ## @param primary.initdb.scriptsConfigMap ConfigMap with scripts to be run at first boot
+    ## NOTE: This will override `primary.initdb.scripts`
+    ##
+    scriptsConfigMap: ""
+    ## @param primary.initdb.scriptsSecret Secret with scripts to be run at first boot (in case it contains sensitive information)
+    ## NOTE: This can work along `primary.initdb.scripts` or `primary.initdb.scriptsConfigMap`
+    ##
+    scriptsSecret: ""
+    ## @param primary.initdb.user Specify the PostgreSQL username to execute the initdb scripts
+    ##
+    user: ""
+    ## @param primary.initdb.password Specify the PostgreSQL password to execute the initdb scripts
+    ##
+    password: ""
+  ## Configure current cluster's primary server to be the standby server in other cluster.
+  ## This will allow cross cluster replication and provide cross cluster high availability.
+  ## You will need to configure pgHbaConfiguration if you want to enable this feature with local cluster replication enabled.
+  ## @param primary.standby.enabled Whether to enable current cluster's primary as standby server of another cluster or not
+  ## @param primary.standby.primaryHost The Host of replication primary in the other cluster
+  ## @param primary.standby.primaryPort The Port of replication primary in the other cluster
   ##
-  securityContext:
+  standby:
     enabled: false
-    runAsUser: 1001
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
-  ## Configure extra options for liveness and readiness probes
+    primaryHost: ""
+    primaryPort: ""
+  ## @param primary.extraEnvVars Array with extra environment variables to add to PostgreSQL Primary nodes
+  ## e.g:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## @param primary.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for PostgreSQL Primary nodes
+  ##
+  extraEnvVarsCM: ""
+  ## @param primary.extraEnvVarsSecret Name of existing Secret containing extra env vars for PostgreSQL Primary nodes
+  ##
+  extraEnvVarsSecret: ""
+  ## @param primary.command Override default container command (useful when using custom images)
+  ##
+  command: []
+  ## @param primary.args Override default container args (useful when using custom images)
+  ##
+  args: []
+  ## Configure extra options for PostgreSQL Primary containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param primary.livenessProbe.enabled Enable livenessProbe on PostgreSQL Primary containers
+  ## @param primary.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param primary.livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param primary.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  ## @param primary.livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param primary.livenessProbe.successThreshold Success threshold for livenessProbe
+  ##
   livenessProbe:
     enabled: true
-    initialDelaySeconds: 5
+    initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5
     failureThreshold: 6
     successThreshold: 1
-
+  ## @param primary.readinessProbe.enabled Enable readinessProbe on PostgreSQL Primary containers
+  ## @param primary.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  ## @param primary.readinessProbe.periodSeconds Period seconds for readinessProbe
+  ## @param primary.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  ## @param primary.readinessProbe.failureThreshold Failure threshold for readinessProbe
+  ## @param primary.readinessProbe.successThreshold Success threshold for readinessProbe
+  ##
   readinessProbe:
     enabled: true
     initialDelaySeconds: 5
@@ -496,3 +385,952 @@ metrics:
     timeoutSeconds: 5
     failureThreshold: 6
     successThreshold: 1
+  ## @param primary.startupProbe.enabled Enable startupProbe on PostgreSQL Primary containers
+  ## @param primary.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param primary.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param primary.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param primary.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param primary.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 15
+    successThreshold: 1
+  ## @param primary.customLivenessProbe Custom livenessProbe that overrides the default one
+  ##
+  customLivenessProbe: {}
+  ## @param primary.customReadinessProbe Custom readinessProbe that overrides the default one
+  ##
+  customReadinessProbe: {}
+  ## @param primary.customStartupProbe Custom startupProbe that overrides the default one
+  ##
+  customStartupProbe: {}
+  ## @param primary.lifecycleHooks for the PostgreSQL Primary container to automate configuration before or after startup
+  ##
+  lifecycleHooks: {}
+  ## PostgreSQL Primary resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param primary.resources.limits The resources limits for the PostgreSQL Primary containers
+  ## @param primary.resources.requests.memory The requested memory for the PostgreSQL Primary containers
+  ## @param primary.resources.requests.cpu The requested cpu for the PostgreSQL Primary containers
+  ##
+  resources:
+    limits: {}
+    requests:
+      memory: 256Mi
+      cpu: 250m
+  ## Pod Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ## @param primary.podSecurityContext.enabled Enable security context
+  ## @param primary.podSecurityContext.fsGroup Group ID for the pod
+  ##
+  podSecurityContext:
+    enabled: true
+    fsGroup: 1001
+  ## Container Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ## @param primary.containerSecurityContext.enabled Enable container security context
+  ## @param primary.containerSecurityContext.runAsUser User ID for the container
+  ##
+  containerSecurityContext:
+    enabled: true
+    runAsUser: 1001
+  ## @param primary.hostAliases PostgreSQL primary pods host aliases
+  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  ##
+  hostAliases: []
+  ## @param primary.hostNetwork Specify if host network should be enabled for PostgreSQL pod (postgresql primary)
+  ##
+  hostNetwork: false
+  ## @param primary.hostIPC Specify if host IPC should be enabled for PostgreSQL pod (postgresql primary)
+  ##
+  hostIPC: false
+  ## @param primary.labels Map of labels to add to the statefulset (postgresql primary)
+  ##
+  labels: {}
+  ## @param primary.annotations Annotations for PostgreSQL primary pods
+  ##
+  annotations: {}
+  ## @param primary.podLabels Map of labels to add to the pods (postgresql primary)
+  ##
+  podLabels: {}
+  ## @param primary.podAnnotations Map of annotations to add to the pods (postgresql primary)
+  ##
+  podAnnotations: {}
+  ## @param primary.podAffinityPreset PostgreSQL primary pod affinity preset. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ##
+  podAffinityPreset: ""
+  ## @param primary.podAntiAffinityPreset PostgreSQL primary pod anti-affinity preset. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ##
+  podAntiAffinityPreset: soft
+  ## PostgreSQL Primary node affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ##
+  nodeAffinityPreset:
+    ## @param primary.nodeAffinityPreset.type PostgreSQL primary node affinity preset type. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`
+    ##
+    type: ""
+    ## @param primary.nodeAffinityPreset.key PostgreSQL primary node label key to match Ignored if `primary.affinity` is set.
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## @param primary.nodeAffinityPreset.values PostgreSQL primary node label values to match. Ignored if `primary.affinity` is set.
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+  ## @param primary.affinity Affinity for PostgreSQL primary pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: primary.podAffinityPreset, primary.podAntiAffinityPreset, and primary.nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+  ## @param primary.nodeSelector Node labels for PostgreSQL primary pods assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  #nodeSelector: {}
+  nodeSelector: {"workerClass": "infra"}
+  ## @param primary.tolerations Tolerations for PostgreSQL primary pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+  ## @param primary.topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
+  ##
+  topologySpreadConstraints: {}
+  ## @param primary.priorityClassName Priority Class to use for each pod (postgresql primary)
+  ##
+  priorityClassName: ""
+  ## @param primary.schedulerName Use an alternate scheduler, e.g. "stork".
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  schedulerName: ""
+  ## @param primary.terminationGracePeriodSeconds Seconds PostgreSQL primary pod needs to terminate gracefully
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
+  ##
+  terminationGracePeriodSeconds: ""
+  ## @param primary.updateStrategy.type PostgreSQL Primary statefulset strategy type
+  ## @param primary.updateStrategy.rollingUpdate PostgreSQL Primary statefulset rolling update configuration parameters
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+  ##
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate: {}
+  ## @param primary.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the PostgreSQL Primary container(s)
+  ##
+  extraVolumeMounts: []
+  ## @param primary.extraVolumes Optionally specify extra list of additional volumes for the PostgreSQL Primary pod(s)
+  ##
+  extraVolumes: []
+  ## @param primary.sidecars Add additional sidecar containers to the PostgreSQL Primary pod(s)
+  ## For example:
+  ## sidecars:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
+  ##
+  sidecars: []
+  ## @param primary.initContainers Add additional init containers to the PostgreSQL Primary pod(s)
+  ## Example
+  ##
+  ## initContainers:
+  ##   - name: do-something
+  ##     image: busybox
+  ##     command: ['do', 'something']
+  ##
+  initContainers: []
+  ## @param primary.extraPodSpec Optionally specify extra PodSpec for the PostgreSQL Primary pod(s)
+  ##
+  extraPodSpec: {}
+  ## PostgreSQL Primary service configuration
+  ##
+  service:
+    ## @param primary.service.type Kubernetes Service type
+    ##
+    type: ClusterIP
+    ## @param primary.service.ports.postgresql PostgreSQL service port
+    ##
+    ports:
+      postgresql: 5432
+    ## Node ports to expose
+    ## NOTE: choose port between <30000-32767>
+    ## @param primary.service.nodePorts.postgresql Node port for PostgreSQL
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    ##
+    nodePorts:
+      postgresql: ""
+    ## @param primary.service.clusterIP Static clusterIP or None for headless services
+    ## e.g:
+    ## clusterIP: None
+    ##
+    clusterIP: ""
+    ## @param primary.service.annotations Annotations for PostgreSQL primary service
+    ##
+    annotations: {}
+    ## @param primary.service.loadBalancerIP Load balancer IP if service type is `LoadBalancer`
+    ## Set the LoadBalancer service type to internal only
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    loadBalancerIP: ""
+    ## @param primary.service.externalTrafficPolicy Enable client source IP preservation
+    ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+    ##
+    externalTrafficPolicy: Cluster
+    ## @param primary.service.loadBalancerSourceRanges Addresses that are allowed when service is LoadBalancer
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    ## loadBalancerSourceRanges:
+    ## - 10.10.10.0/24
+    ##
+    loadBalancerSourceRanges: []
+    ## @param primary.service.extraPorts Extra ports to expose in the PostgreSQL primary service
+    ##
+    extraPorts: []
+  ## PostgreSQL Primary persistence configuration
+  ##
+  persistence:
+    ## @param primary.persistence.enabled Enable PostgreSQL Primary data persistence using PVC
+    ##
+    enabled: true
+    ## @param primary.persistence.existingClaim Name of an existing PVC to use
+    ##
+    existingClaim: ""
+    ## @param primary.persistence.mountPath The path the volume will be mounted at
+    ## Note: useful when using custom PostgreSQL images
+    ##
+    mountPath: /bitnami/postgresql
+    ## @param primary.persistence.subPath The subdirectory of the volume to mount to
+    ## Useful in dev environments and one PV for multiple services
+    ##
+    subPath: ""
+    ## @param primary.persistence.storageClass PVC Storage Class for PostgreSQL Primary data volume
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    storageClass: "rook-ceph-block" #changeme
+    ## @param primary.persistence.accessModes PVC Access Mode for PostgreSQL volume
+    ##
+    accessModes:
+      - ReadWriteOnce
+    ## @param primary.persistence.size PVC Storage Request for PostgreSQL volume
+    ##
+    size: 10Gi
+    ## @param primary.persistence.annotations Annotations for the PVC
+    ##
+    annotations: {}
+    ## @param primary.persistence.selector Selector to match an existing Persistent Volume (this value is evaluated as a template)
+    ## selector:
+    ##   matchLabels:
+    ##     app: my-app
+    ##
+    selector: {}
+    ## @param primary.persistence.dataSource Custom PVC data source
+    ##
+    dataSource: {}
+
+## @section PostgreSQL read only replica parameters
+##
+readReplicas:
+  ## @param readReplicas.replicaCount Number of PostgreSQL read only replicas
+  ##
+  replicaCount: 1
+  ## @param readReplicas.extraEnvVars Array with extra environment variables to add to PostgreSQL read only nodes
+  ## e.g:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## @param readReplicas.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for PostgreSQL read only nodes
+  ##
+  extraEnvVarsCM: ""
+  ## @param readReplicas.extraEnvVarsSecret Name of existing Secret containing extra env vars for PostgreSQL read only nodes
+  ##
+  extraEnvVarsSecret: ""
+  ## @param readReplicas.command Override default container command (useful when using custom images)
+  ##
+  command: []
+  ## @param readReplicas.args Override default container args (useful when using custom images)
+  ##
+  args: []
+  ## Configure extra options for PostgreSQL read only containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param readReplicas.livenessProbe.enabled Enable livenessProbe on PostgreSQL read only containers
+  ## @param readReplicas.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param readReplicas.livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param readReplicas.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  ## @param readReplicas.livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param readReplicas.livenessProbe.successThreshold Success threshold for livenessProbe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  ## @param readReplicas.readinessProbe.enabled Enable readinessProbe on PostgreSQL read only containers
+  ## @param readReplicas.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  ## @param readReplicas.readinessProbe.periodSeconds Period seconds for readinessProbe
+  ## @param readReplicas.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  ## @param readReplicas.readinessProbe.failureThreshold Failure threshold for readinessProbe
+  ## @param readReplicas.readinessProbe.successThreshold Success threshold for readinessProbe
+  ##
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  ## @param readReplicas.startupProbe.enabled Enable startupProbe on PostgreSQL read only containers
+  ## @param readReplicas.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param readReplicas.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param readReplicas.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param readReplicas.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param readReplicas.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 15
+    successThreshold: 1
+  ## @param readReplicas.customLivenessProbe Custom livenessProbe that overrides the default one
+  ##
+  customLivenessProbe: {}
+  ## @param readReplicas.customReadinessProbe Custom readinessProbe that overrides the default one
+  ##
+  customReadinessProbe: {}
+  ## @param readReplicas.customStartupProbe Custom startupProbe that overrides the default one
+  ##
+  customStartupProbe: {}
+  ## @param readReplicas.lifecycleHooks for the PostgreSQL read only container to automate configuration before or after startup
+  ##
+  lifecycleHooks: {}
+  ## PostgreSQL read only resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param readReplicas.resources.limits The resources limits for the PostgreSQL read only containers
+  ## @param readReplicas.resources.requests.memory The requested memory for the PostgreSQL read only containers
+  ## @param readReplicas.resources.requests.cpu The requested cpu for the PostgreSQL read only containers
+  ##
+  resources:
+    limits: {}
+    requests:
+      memory: 256Mi
+      cpu: 250m
+  ## Pod Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ## @param readReplicas.podSecurityContext.enabled Enable security context
+  ## @param readReplicas.podSecurityContext.fsGroup Group ID for the pod
+  ##
+  podSecurityContext:
+    enabled: true
+    fsGroup: 1001
+  ## Container Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ## @param readReplicas.containerSecurityContext.enabled Enable container security context
+  ## @param readReplicas.containerSecurityContext.runAsUser User ID for the container
+  ##
+  containerSecurityContext:
+    enabled: true
+    runAsUser: 1001
+  ## @param readReplicas.hostAliases PostgreSQL read only pods host aliases
+  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  ##
+  hostAliases: []
+  ## @param readReplicas.hostNetwork Specify if host network should be enabled for PostgreSQL pod (PostgreSQL read only)
+  ##
+  hostNetwork: false
+  ## @param readReplicas.hostIPC Specify if host IPC should be enabled for PostgreSQL pod (postgresql primary)
+  ##
+  hostIPC: false
+  ## @param readReplicas.labels Map of labels to add to the statefulset (PostgreSQL read only)
+  ##
+  labels: {}
+  ## @param readReplicas.annotations Annotations for PostgreSQL read only pods
+  ##
+  annotations: {}
+  ## @param readReplicas.podLabels Map of labels to add to the pods (PostgreSQL read only)
+  ##
+  podLabels: {}
+  ## @param readReplicas.podAnnotations Map of annotations to add to the pods (PostgreSQL read only)
+  ##
+  podAnnotations: {}
+  ## @param readReplicas.podAffinityPreset PostgreSQL read only pod affinity preset. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ##
+  podAffinityPreset: ""
+  ## @param readReplicas.podAntiAffinityPreset PostgreSQL read only pod anti-affinity preset. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ##
+  podAntiAffinityPreset: soft
+  ## PostgreSQL read only node affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ##
+  nodeAffinityPreset:
+    ## @param readReplicas.nodeAffinityPreset.type PostgreSQL read only node affinity preset type. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`
+    ##
+    type: ""
+    ## @param readReplicas.nodeAffinityPreset.key PostgreSQL read only node label key to match Ignored if `primary.affinity` is set.
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## @param readReplicas.nodeAffinityPreset.values PostgreSQL read only node label values to match. Ignored if `primary.affinity` is set.
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+  ## @param readReplicas.affinity Affinity for PostgreSQL read only pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: primary.podAffinityPreset, primary.podAntiAffinityPreset, and primary.nodeAffinityPreset will be ignored when it's set
+  ##
+  affinity: {}
+  ## @param readReplicas.nodeSelector Node labels for PostgreSQL read only pods assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+  ## @param readReplicas.tolerations Tolerations for PostgreSQL read only pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+  ## @param readReplicas.topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
+  ##
+  topologySpreadConstraints: {}
+  ## @param readReplicas.priorityClassName Priority Class to use for each pod (PostgreSQL read only)
+  ##
+  priorityClassName: ""
+  ## @param readReplicas.schedulerName Use an alternate scheduler, e.g. "stork".
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  schedulerName: ""
+  ## @param readReplicas.terminationGracePeriodSeconds Seconds PostgreSQL read only pod needs to terminate gracefully
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
+  ##
+  terminationGracePeriodSeconds: ""
+  ## @param readReplicas.updateStrategy.type PostgreSQL read only statefulset strategy type
+  ## @param readReplicas.updateStrategy.rollingUpdate PostgreSQL read only statefulset rolling update configuration parameters
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+  ##
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate: {}
+  ## @param readReplicas.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the PostgreSQL read only container(s)
+  ##
+  extraVolumeMounts: []
+  ## @param readReplicas.extraVolumes Optionally specify extra list of additional volumes for the PostgreSQL read only pod(s)
+  ##
+  extraVolumes: []
+  ## @param readReplicas.sidecars Add additional sidecar containers to the PostgreSQL read only pod(s)
+  ## For example:
+  ## sidecars:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
+  ##
+  sidecars: []
+  ## @param readReplicas.initContainers Add additional init containers to the PostgreSQL read only pod(s)
+  ## Example
+  ##
+  ## initContainers:
+  ##   - name: do-something
+  ##     image: busybox
+  ##     command: ['do', 'something']
+  ##
+  initContainers: []
+  ## @param readReplicas.extraPodSpec Optionally specify extra PodSpec for the PostgreSQL read only pod(s)
+  ##
+  extraPodSpec: {}
+  ## PostgreSQL read only service configuration
+  ##
+  service:
+    ## @param readReplicas.service.type Kubernetes Service type
+    ##
+    type: ClusterIP
+    ## @param readReplicas.service.ports.postgresql PostgreSQL service port
+    ##
+    ports:
+      postgresql: 5432
+    ## Node ports to expose
+    ## NOTE: choose port between <30000-32767>
+    ## @param readReplicas.service.nodePorts.postgresql Node port for PostgreSQL
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    ##
+    nodePorts:
+      postgresql: ""
+    ## @param readReplicas.service.clusterIP Static clusterIP or None for headless services
+    ## e.g:
+    ## clusterIP: None
+    ##
+    clusterIP: ""
+    ## @param readReplicas.service.annotations Annotations for PostgreSQL read only service
+    ##
+    annotations: {}
+    ## @param readReplicas.service.loadBalancerIP Load balancer IP if service type is `LoadBalancer`
+    ## Set the LoadBalancer service type to internal only
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    loadBalancerIP: ""
+    ## @param readReplicas.service.externalTrafficPolicy Enable client source IP preservation
+    ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+    ##
+    externalTrafficPolicy: Cluster
+    ## @param readReplicas.service.loadBalancerSourceRanges Addresses that are allowed when service is LoadBalancer
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    ## loadBalancerSourceRanges:
+    ## - 10.10.10.0/24
+    ##
+    loadBalancerSourceRanges: []
+    ## @param readReplicas.service.extraPorts Extra ports to expose in the PostgreSQL read only service
+    ##
+    extraPorts: []
+  ## PostgreSQL read only persistence configuration
+  ##
+  persistence:
+    ## @param readReplicas.persistence.enabled Enable PostgreSQL read only data persistence using PVC
+    ##
+    enabled: true
+    ## @param readReplicas.persistence.mountPath The path the volume will be mounted at
+    ## Note: useful when using custom PostgreSQL images
+    ##
+    mountPath: /bitnami/postgresql
+    ## @param readReplicas.persistence.subPath The subdirectory of the volume to mount to
+    ## Useful in dev environments and one PV for multiple services
+    ##
+    subPath: ""
+    ## @param readReplicas.persistence.storageClass PVC Storage Class for PostgreSQL read only data volume
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    storageClass: ""
+    ## @param readReplicas.persistence.accessModes PVC Access Mode for PostgreSQL volume
+    ##
+    accessModes:
+      - ReadWriteOnce
+    ## @param readReplicas.persistence.size PVC Storage Request for PostgreSQL volume
+    ##
+    size: 8Gi
+    ## @param readReplicas.persistence.annotations Annotations for the PVC
+    ##
+    annotations: {}
+    ## @param readReplicas.persistence.selector Selector to match an existing Persistent Volume (this value is evaluated as a template)
+    ## selector:
+    ##   matchLabels:
+    ##     app: my-app
+    ##
+    selector: {}
+    ## @param readReplicas.persistence.dataSource Custom PVC data source
+    ##
+    dataSource: {}
+
+## @section NetworkPolicy parameters
+
+## Add networkpolicies
+##
+networkPolicy:
+  ## @param networkPolicy.enabled Enable network policies
+  ##
+  enabled: false
+  ## @param networkPolicy.metrics.enabled Enable network policies for metrics (prometheus)
+  ## @param networkPolicy.metrics.namespaceSelector [object] Monitoring namespace selector labels. These labels will be used to identify the prometheus' namespace.
+  ## @param networkPolicy.metrics.podSelector [object] Monitoring pod selector labels. These labels will be used to identify the Prometheus pods.
+  ##
+  metrics:
+    enabled: false
+    ## e.g:
+    ## namespaceSelector:
+    ##   label: monitoring
+    ##
+    namespaceSelector: {}
+    ## e.g:
+    ## podSelector:
+    ##   label: monitoring
+    ##
+    podSelector: {}
+  ## Ingress Rules
+  ##
+  ingressRules:
+    ## @param networkPolicy.ingressRules.primaryAccessOnlyFrom.enabled Enable ingress rule that makes PostgreSQL primary node only accessible from a particular origin.
+    ## @param networkPolicy.ingressRules.primaryAccessOnlyFrom.namespaceSelector [object] Namespace selector label that is allowed to access the PostgreSQL primary node. This label will be used to identified the allowed namespace(s).
+    ## @param networkPolicy.ingressRules.primaryAccessOnlyFrom.podSelector [object] Pods selector label that is allowed to access the PostgreSQL primary node. This label will be used to identified the allowed pod(s).
+    ## @param networkPolicy.ingressRules.primaryAccessOnlyFrom.customRules [object] Custom network policy for the PostgreSQL primary node.
+    ##
+    primaryAccessOnlyFrom:
+      enabled: false
+      ## e.g:
+      ## namespaceSelector:
+      ##   label: ingress
+      ##
+      namespaceSelector: {}
+      ## e.g:
+      ## podSelector:
+      ##   label: access
+      ##
+      podSelector: {}
+      ## custom ingress rules
+      ## e.g:
+      ## customRules:
+      ##   - from:
+      ##       - namespaceSelector:
+      ##           matchLabels:
+      ##             label: example
+      customRules: {}
+    ## @param networkPolicy.ingressRules.readReplicasAccessOnlyFrom.enabled Enable ingress rule that makes PostgreSQL read-only nodes only accessible from a particular origin.
+    ## @param networkPolicy.ingressRules.readReplicasAccessOnlyFrom.namespaceSelector [object] Namespace selector label that is allowed to access the PostgreSQL read-only nodes. This label will be used to identified the allowed namespace(s).
+    ## @param networkPolicy.ingressRules.readReplicasAccessOnlyFrom.podSelector [object] Pods selector label that is allowed to access the PostgreSQL read-only nodes. This label will be used to identified the allowed pod(s).
+    ## @param networkPolicy.ingressRules.readReplicasAccessOnlyFrom.customRules [object] Custom network policy for the PostgreSQL read-only nodes.
+    ##
+    readReplicasAccessOnlyFrom:
+      enabled: false
+      ## e.g:
+      ## namespaceSelector:
+      ##   label: ingress
+      ##
+      namespaceSelector: {}
+      ## e.g:
+      ## podSelector:
+      ##   label: access
+      ##
+      podSelector: {}
+      ## custom ingress rules
+      ## e.g:
+      ## CustomRules:
+      ##   - from:
+      ##       - namespaceSelector:
+      ##           matchLabels:
+      ##             label: example
+      customRules: {}
+  ## @param networkPolicy.egressRules.denyConnectionsToExternal Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).
+  ## @param networkPolicy.egressRules.customRules [object] Custom network policy rule
+  ##
+  egressRules:
+    # Deny connections to external. This is not compatible with an external database.
+    denyConnectionsToExternal: false
+    ## Additional custom egress rules
+    ## e.g:
+    ## customRules:
+    ##   - to:
+    ##       - namespaceSelector:
+    ##           matchLabels:
+    ##             label: example
+    customRules: {}
+
+## @section Volume Permissions parameters
+
+## Init containers parameters:
+## volumePermissions: Change the owner and group of the persistent volume(s) mountpoint(s) to 'runAsUser:fsGroup' on each node
+##
+volumePermissions:
+  ## @param volumePermissions.enabled Enable init container that changes the owner and group of the persistent volume
+  ##
+  enabled: false
+  ## @param volumePermissions.image.registry Init container volume-permissions image registry
+  ## @param volumePermissions.image.repository Init container volume-permissions image repository
+  ## @param volumePermissions.image.tag Init container volume-permissions image tag (immutable tags are recommended)
+  ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
+  ## @param volumePermissions.image.pullSecrets Init container volume-permissions image pull secrets
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/bitnami-shell
+    tag: 10-debian-10-r350
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  ## Init container resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param volumePermissions.resources.limits Init container volume-permissions resource limits
+  ## @param volumePermissions.resources.requests Init container volume-permissions resource requests
+  ##
+  resources:
+    limits: {}
+    requests: {}
+  ## Init container' Security Context
+  ## Note: the chown of the data folder is done to containerSecurityContext.runAsUser
+  ## and not the below volumePermissions.containerSecurityContext.runAsUser
+  ## @param volumePermissions.containerSecurityContext.runAsUser User ID for the init container
+  ##
+  containerSecurityContext:
+    runAsUser: 0
+
+## @section Other Parameters
+
+## Service account for PostgreSQL to use.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  ## @param serviceAccount.create Enable creation of ServiceAccount for PostgreSQL pod
+  ##
+  create: false
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the common.names.fullname template
+  ##
+  name: ""
+  ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+  ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+  ##
+  automountServiceAccountToken: true
+  ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
+  ##
+  annotations: {}
+## Creates role for ServiceAccount
+## @param rbac.create Create Role and RoleBinding (required for PSP to work)
+##
+rbac:
+  create: false
+  ## @param rbac.rules Custom RBAC rules to set
+  ## e.g:
+  ## rules:
+  ##   - apiGroups:
+  ##       - ""
+  ##     resources:
+  ##       - pods
+  ##     verbs:
+  ##       - get
+  ##       - list
+  ##
+  rules: []
+## Pod Security Policy
+## ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+## @param psp.create Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later
+##
+psp:
+  create: false
+
+## @section Metrics Parameters
+
+metrics:
+  ## @param metrics.enabled Start a prometheus exporter
+  ##
+  enabled: false
+  ## @param metrics.image.registry PostgreSQL Prometheus Exporter image registry
+  ## @param metrics.image.repository PostgreSQL Prometheus Exporter image repository
+  ## @param metrics.image.tag PostgreSQL Prometheus Exporter image tag (immutable tags are recommended)
+  ## @param metrics.image.pullPolicy PostgreSQL Prometheus Exporter image pull policy
+  ## @param metrics.image.pullSecrets Specify image pull secrets
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/postgres-exporter
+    tag: 0.10.1-debian-10-r37
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  ## @param metrics.customMetrics Define additional custom metrics
+  ## ref: https://github.com/wrouesnel/postgres_exporter#adding-new-metrics-via-a-config-file
+  ## customMetrics:
+  ##   pg_database:
+  ##     query: "SELECT d.datname AS name, CASE WHEN pg_catalog.has_database_privilege(d.datname, 'CONNECT') THEN pg_catalog.pg_database_size(d.datname) ELSE 0 END AS size_bytes FROM pg_catalog.pg_database d where datname not in ('template0', 'template1', 'postgres')"
+  ##     metrics:
+  ##       - name:
+  ##           usage: "LABEL"
+  ##           description: "Name of the database"
+  ##       - size_bytes:
+  ##           usage: "GAUGE"
+  ##           description: "Size of the database in bytes"
+  ##
+  customMetrics: {}
+  ## @param metrics.extraEnvVars Extra environment variables to add to PostgreSQL Prometheus exporter
+  ## see: https://github.com/wrouesnel/postgres_exporter#environment-variables
+  ## For example:
+  ##  extraEnvVars:
+  ##  - name: PG_EXPORTER_DISABLE_DEFAULT_METRICS
+  ##    value: "true"
+  ##
+  extraEnvVars: []
+  ## PostgreSQL Prometheus exporter containers' Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param metrics.containerSecurityContext.enabled Enable PostgreSQL Prometheus exporter containers' Security Context
+  ## @param metrics.containerSecurityContext.runAsUser Set PostgreSQL Prometheus exporter containers' Security Context runAsUser
+  ## @param metrics.containerSecurityContext.runAsNonRoot Set PostgreSQL Prometheus exporter containers' Security Context runAsNonRoot
+  ##
+  containerSecurityContext:
+    enabled: true
+    runAsUser: 1001
+    runAsNonRoot: true
+  ## Configure extra options for PostgreSQL Prometheus exporter containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param metrics.livenessProbe.enabled Enable livenessProbe on PostgreSQL Prometheus exporter containers
+  ## @param metrics.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param metrics.livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param metrics.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  ## @param metrics.livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param metrics.livenessProbe.successThreshold Success threshold for livenessProbe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  ## @param metrics.readinessProbe.enabled Enable readinessProbe on PostgreSQL Prometheus exporter containers
+  ## @param metrics.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  ## @param metrics.readinessProbe.periodSeconds Period seconds for readinessProbe
+  ## @param metrics.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  ## @param metrics.readinessProbe.failureThreshold Failure threshold for readinessProbe
+  ## @param metrics.readinessProbe.successThreshold Success threshold for readinessProbe
+  ##
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  ## @param metrics.startupProbe.enabled Enable startupProbe on PostgreSQL Prometheus exporter containers
+  ## @param metrics.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param metrics.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param metrics.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param metrics.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param metrics.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 15
+    successThreshold: 1
+  ## @param metrics.customLivenessProbe Custom livenessProbe that overrides the default one
+  ##
+  customLivenessProbe: {}
+  ## @param metrics.customReadinessProbe Custom readinessProbe that overrides the default one
+  ##
+  customReadinessProbe: {}
+  ## @param metrics.customStartupProbe Custom startupProbe that overrides the default one
+  ##
+  customStartupProbe: {}
+  ## @param metrics.containerPorts.metrics PostgreSQL Prometheus exporter metrics container port
+  ##
+  containerPorts:
+    metrics: 9187
+  ## PostgreSQL Prometheus exporter resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param metrics.resources.limits The resources limits for the PostgreSQL Prometheus exporter container
+  ## @param metrics.resources.requests The requested resources for the PostgreSQL Prometheus exporter container
+  ##
+  resources:
+    limits: {}
+    requests: {}
+  ## Service configuration
+  ##
+  service:
+    ## @param metrics.service.ports.metrics PostgreSQL Prometheus Exporter service port
+    ##
+    ports:
+      metrics: 9187
+    ## @param metrics.service.clusterIP Static clusterIP or None for headless services
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address
+    ##
+    clusterIP: ""
+    ## @param metrics.service.sessionAffinity Control where client requests go, to the same pod or round-robin
+    ## Values: ClientIP or None
+    ## ref: https://kubernetes.io/docs/user-guide/services/
+    ##
+    sessionAffinity: None
+    ## @param metrics.service.annotations [object] Annotations for Prometheus to auto-discover the metrics endpoint
+    ##
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "{{ .Values.metrics.service.ports.metrics }}"
+  ## Prometheus Operator ServiceMonitor configuration
+  ##
+  serviceMonitor:
+    ## @param metrics.serviceMonitor.enabled Create ServiceMonitor Resource for scraping metrics using Prometheus Operator
+    ##
+    enabled: false
+    ## @param metrics.serviceMonitor.namespace Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)
+    ##
+    namespace: ""
+    ## @param metrics.serviceMonitor.interval Interval at which metrics should be scraped.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    interval: ""
+    ## @param metrics.serviceMonitor.scrapeTimeout Timeout after which the scrape is ended
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    ##
+    scrapeTimeout: ""
+    ## @param metrics.serviceMonitor.labels Additional labels that can be used so ServiceMonitor will be discovered by Prometheus
+    ##
+    labels: {}
+    ## @param metrics.serviceMonitor.selector Prometheus instance selector labels
+    ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
+    ##
+    selector: {}
+    ## @param metrics.serviceMonitor.relabelings RelabelConfigs to apply to samples before scraping
+    ##
+    relabelings: []
+    ## @param metrics.serviceMonitor.metricRelabelings MetricRelabelConfigs to apply to samples before ingestion
+    ##
+    metricRelabelings: []
+    ## @param metrics.serviceMonitor.honorLabels Specify honorLabels parameter to add the scrape endpoint
+    ##
+    honorLabels: false
+    ## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in prometheus.
+    ##
+    jobLabel: ""
+  ## Custom PrometheusRule to be defined
+  ## The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart
+  ## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
+  ##
+  prometheusRule:
+    ## @param metrics.prometheusRule.enabled Create a PrometheusRule for Prometheus Operator
+    ##
+    enabled: false
+    ## @param metrics.prometheusRule.namespace Namespace for the PrometheusRule Resource (defaults to the Release Namespace)
+    ##
+    namespace: ""
+    ## @param metrics.prometheusRule.labels Additional labels that can be used so PrometheusRule will be discovered by Prometheus
+    ##
+    labels: {}
+    ## @param metrics.prometheusRule.rules PrometheusRule definitions
+    ## Make sure to constraint the rules to the current postgresql service.
+    ## rules:
+    ##   - alert: HugeReplicationLag
+    ##     expr: pg_replication_lag{service="{{ printf "%s-metrics" (include "common.names.fullname" .) }}"} / 3600 > 1
+    ##     for: 1m
+    ##     labels:
+    ##       severity: critical
+    ##     annotations:
+    ##       description: replication for {{ include "common.names.fullname" . }} PostgreSQL is lagging by {{ "{{ $value }}" }} hour(s).
+    ##       summary: PostgreSQL replication is lagging by {{ "{{ $value }}" }} hour(s).
+    ##
+    rules: []

--- a/redis-values.yaml
+++ b/redis-values.yaml
@@ -6,7 +6,7 @@
 #   imageRegistry: myRegistryName
 #   imagePullSecrets:
 #     - myRegistryKeySecretName
-#  storageClass: 
+#  storageClass:
 
 ## Bitnami Redis image version
 ## ref: https://hub.docker.com/r/bitnami/redis/tags/
@@ -17,7 +17,7 @@ image:
   ## Bitnami Redis image tag
   ## ref: https://github.com/bitnami/bitnami-docker-redis#supported-tags-and-respective-dockerfile-links
   ##
-  tag: 5.0.5-debian-9-r124
+  tag: 5.0.5-debian-9-r181
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -56,7 +56,7 @@ sentinel:
     ## Bitnami Redis image tag
     ## ref: https://github.com/bitnami/bitnami-docker-redis-sentinel#supported-tags-and-respective-dockerfile-links
     ##
-    tag: 5.0.5-debian-9-r119
+    tag: 5.0.5-debian-9-r174
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/redis-values.yaml
+++ b/redis-values.yaml
@@ -1,544 +1,1485 @@
+## @section Global parameters
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
-## Current available global Docker image parameters: imageRegistry and imagePullSecrets
+## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
 ##
-# global:
-#   imageRegistry: myRegistryName
-#   imagePullSecrets:
-#     - myRegistryKeySecretName
-#  storageClass:
 
-## Bitnami Redis image version
+## @param global.imageRegistry Global Docker image registry
+## @param global.imagePullSecrets Global Docker registry secret names as an array
+## @param global.storageClass Global StorageClass for Persistent Volume(s)
+## @param global.redis.password Global Redis&trade; password (overrides `auth.password`)
+##
+global:
+  imageRegistry: ""
+  ## E.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
+  storageClass: ""
+  redis:
+    password: ""
+
+## @section Common parameters
+##
+
+## @param kubeVersion Override Kubernetes version
+##
+kubeVersion: ""
+## @param nameOverride String to partially override common.names.fullname
+##
+nameOverride: ""
+## @param fullnameOverride String to fully override common.names.fullname
+##
+fullnameOverride: ""
+## @param commonLabels Labels to add to all deployed objects
+##
+commonLabels: {}
+## @param commonAnnotations Annotations to add to all deployed objects
+##
+commonAnnotations: {}
+## @param clusterDomain Kubernetes cluster domain name
+##
+clusterDomain: cluster.local #changeme
+## @param extraDeploy Array of extra objects to deploy with the release
+##
+extraDeploy: []
+
+## Enable diagnostic mode in the deployment
+##
+diagnosticMode:
+  ## @param diagnosticMode.enabled Enable diagnostic mode (all probes will be disabled and the command will be overridden)
+  ##
+  enabled: false
+  ## @param diagnosticMode.command Command to override all containers in the deployment
+  ##
+  command:
+    - sleep
+  ## @param diagnosticMode.args Args to override all containers in the deployment
+  ##
+  args:
+    - infinity
+
+## @section Redis&trade; Image parameters
+##
+
+## Bitnami Redis&trade; image
 ## ref: https://hub.docker.com/r/bitnami/redis/tags/
+## @param image.registry Redis&trade; image registry
+## @param image.repository Redis&trade; image repository
+## @param image.tag Redis&trade; image tag (immutable tags are recommended)
+## @param image.pullPolicy Redis&trade; image pull policy
+## @param image.pullSecrets Redis&trade; image pull secrets
+## @param image.debug Enable image debug mode
 ##
 image:
   registry: docker.io
   repository: bitnami/redis
-  ## Bitnami Redis image tag
-  ## ref: https://github.com/bitnami/bitnami-docker-redis#supported-tags-and-respective-dockerfile-links
-  ##
-  tag: 5.0.5-debian-9-r181
+  tag: 6.2.6-debian-10-r142
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## e.g:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
   ##
-  # pullSecrets:
-  #   - myRegistryKeySecretName
+  pullSecrets: []
+  ## Enable debug mode
+  ##
+  debug: false
 
-## String to partially override redis.fullname template (will maintain the release name)
+## @section Redis&trade; common configuration parameters
+## https://github.com/bitnami/bitnami-docker-redis#configuration
 ##
-# nameOverride:
 
-## String to fully override redis.fullname template
+## @param architecture Redis&trade; architecture. Allowed values: `standalone` or `replication`
 ##
-# fullnameOverride:
-
-## Cluster settings
-cluster:
-  enabled: true
-  slaveCount: 3
-
-## Use redis sentinel in the redis pod. This will disable the master and slave services and
-## create one redis service with ports to the sentinel and the redis instances
-sentinel:
-  enabled: false
-  ## Bitnami Redis Sentintel image version
-  ## ref: https://hub.docker.com/r/bitnami/redis-sentinel/tags/
-  ##
-  image:
-    registry: docker.io
-    repository: bitnami/redis-sentinel
-    ## Bitnami Redis image tag
-    ## ref: https://github.com/bitnami/bitnami-docker-redis-sentinel#supported-tags-and-respective-dockerfile-links
-    ##
-    tag: 5.0.5-debian-9-r174
-    ## Specify a imagePullPolicy
-    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-    ##
-    pullPolicy: IfNotPresent
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ##
-    # pullSecrets:
-    #   - myRegistryKeySecretName
-  masterSet: mymaster
-  initialCheckTimeout: 5
-  quorum: 2
-  downAfterMilliseconds: 60000
-  failoverTimeout: 18000
-  parallelSyncs: 1
-  port: 26379
-  ## Additional Redis configuration for the sentinel nodes
-  ## ref: https://redis.io/topics/config
-  ##
-  configmap:
-  ## Configure extra options for Redis Sentinel liveness and readiness probes
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
-  ##
-  livenessProbe:
-    enabled: true
-    initialDelaySeconds: 5
-    periodSeconds: 5
-    timeoutSeconds: 5
-    successThreshold: 1
-    failureThreshold: 5
-  readinessProbe:
-    enabled: true
-    initialDelaySeconds: 5
-    periodSeconds: 5
-    timeoutSeconds: 1
-    successThreshold: 1
-    failureThreshold: 5
-  ## Redis Sentinel resource requests and limits
-  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-  # resources:
-  #   requests:
-  #     memory: 256Mi
-  #     cpu: 100m
-  ## Redis Sentinel Service properties
-  service:
-    ##  Redis Sentinel Service type
-    type: ClusterIP
-    sentinelPort: 26379
-    redisPort: 6379
-
-    ## Specify the nodePort value for the LoadBalancer and NodePort service types.
-    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
-    ##
-    # sentinelNodePort:
-    # redisNodePort:
-
-    ## Provide any additional annotations which may be required. This can be used to
-    ## set the LoadBalancer service type to internal only.
-    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
-    ##
-    annotations: {}
-    loadBalancerIP:
-
-## Specifies the Kubernetes Cluster's Domain Name.
-##
-clusterDomain: cluster.local
-
-networkPolicy:
-  ## Specifies whether a NetworkPolicy should be created
-  ##
-  enabled: true
-
-  ## The Policy model to apply. When set to false, only pods with the correct
-  ## client label will have network access to the port Redis is listening
-  ## on. When true, Redis will accept connections from any source
-  ## (with the correct destination port).
-  ##
-  # allowExternal: true
-
-serviceAccount:
-  ## Specifies whether a ServiceAccount should be created
-  ##
-  create: false
-  ## The name of the ServiceAccount to use.
-  ## If not set and create is true, a name is generated using the fullname template
-  name:
-
-rbac:
-  ## Specifies whether RBAC resources should be created
-  ##
-  create: false
-
-  role:
-    ## Rules to create. It follows the role specification
-    # rules:
-    #  - apiGroups:
-    #    - extensions
-    #    resources:
-    #      - podsecuritypolicies
-    #    verbs:
-    #      - use
-    #    resourceNames:
-    #      - gce.unprivileged
-    rules: []
-
-## Redis pod Security Context
-securityContext:
-  enabled: true
-  fsGroup: 1001
-  runAsUser: 1001
-
-## Use password authentication
-usePassword: true
-## Redis password (both master and slave)
-## Defaults to a random 10-character alphanumeric string if not set and usePassword is true
+architecture: replication
+## Redis&trade; Authentication parameters
 ## ref: https://github.com/bitnami/bitnami-docker-redis#setting-the-server-password-on-first-run
 ##
-password:
-## Use existing secret (ignores previous password)
-# existingSecret:
-
-## Mount secrets as files instead of environment variables
-usePasswordFile: false
-
-## Persist data to a persistent volume (Redis Master)
-persistence: {}
-  ## A manually managed Persistent Volume and Claim
-  ## Requires persistence.enabled: true
-  ## If defined, PVC must be created manually before volume will be bound
-  # existingClaim:
-
-# Redis port
-redisPort: 6379
-
-##
-## Redis Master parameters
-##
-master:
-  ## Redis command arguments
+auth:
+  ## @param auth.enabled Enable password authentication
   ##
-  ## Can be used to specify command line arguments, for example:
-  ##
-  command: "/run.sh"
-  ## Additional Redis configuration for the master nodes
-  ## ref: https://redis.io/topics/config
-  ##
-  configmap:
-  ## Redis additional command line flags
-  ##
-  ## Can be used to specify command line flags, for example:
-  ##
-  ## extraFlags:
-  ##  - "--maxmemory-policy volatile-ttl"
-  ##  - "--repl-backlog-size 1024mb"
-  extraFlags: []
-  ## Comma-separated list of Redis commands to disable
-  ##
-  ## Can be used to disable Redis commands for security reasons.
-  ## Commands will be completely disabled by renaming each to an empty string.
-  ## ref: https://redis.io/topics/security#disabling-of-specific-commands
-  ##
-  disableCommands:
-  - FLUSHDB
-  - FLUSHALL
-
-  ## Redis Master additional pod labels and annotations
-  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-  podLabels: {}
-  podAnnotations: {}
-
-  ## Redis Master resource requests and limits
-  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-  # resources:
-  #   requests:
-  #     memory: 256Mi
-  #     cpu: 100m
-  ## Use an alternate scheduler, e.g. "stork".
-  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
-  ##
-  # schedulerName:
-
-  ## Configure extra options for Redis Master liveness and readiness probes
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
-  ##
-  livenessProbe:
-    enabled: true
-    initialDelaySeconds: 5
-    periodSeconds: 5
-    timeoutSeconds: 5
-    successThreshold: 1
-    failureThreshold: 5
-  readinessProbe:
-    enabled: true
-    initialDelaySeconds: 5
-    periodSeconds: 5
-    timeoutSeconds: 1
-    successThreshold: 1
-    failureThreshold: 5
-
-  ## Redis Master Node selectors and tolerations for pod assignment
-  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
-  ##
-  # nodeSelector: {"beta.kubernetes.io/arch": "amd64"}
-  # tolerations: []
-  ## Redis Master pod/node affinity/anti-affinity
-  ##
-  affinity: {}
-
-  ## Redis Master Service properties
-  service:
-    ##  Redis Master Service type
-    type: ClusterIP
-    port: 6379
-
-    ## Specify the nodePort value for the LoadBalancer and NodePort service types.
-    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
-    ##
-    # nodePort:
-
-    ## Provide any additional annotations which may be required. This can be used to
-    ## set the LoadBalancer service type to internal only.
-    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
-    ##
-    annotations: {}
-    loadBalancerIP:
-
-  ## Enable persistence using Persistent Volume Claims
-  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-  ##
-  persistence:
-    enabled: true
-    ## The path the volume will be mounted at, useful when using different
-    ## Redis images.
-    path: /data
-    ## The subdirectory of the volume to mount to, useful in dev environments
-    ## and one PV for multiple services.
-    subPath: ""
-    ## redis data Persistent Volume Storage Class
-    ## If defined, storageClassName: <storageClass>
-    ## If set to "-", storageClassName: "", which disables dynamic provisioning
-    ## If undefined (the default) or set to null, no storageClassName spec is
-    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-    ##   GKE, AWS & OpenStack)
-    ##
-    storageClass: rook-ceph-block #changeme
-    accessModes:
-    - ReadWriteOnce
-    size: 8Gi
-
-  ## Update strategy, can be set to RollingUpdate or onDelete by default.
-  ## https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets
-  statefulset:
-    updateStrategy: RollingUpdate
-    ## Partition update strategy
-    ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
-    # rollingUpdatePartition:
-
-  ## Redis Master pod priorityClassName
-  # priorityClassName: {}
-
-##
-## Redis Slave properties
-## Note: service.type is a mandatory parameter
-## The rest of the parameters are either optional or, if undefined, will inherit those declared in Redis Master
-##
-slave:
-  ## Slave Service properties
-  service:
-    ## Redis Slave Service type
-    type: ClusterIP
-    ## Redis port
-    port: 6379
-    ## Specify the nodePort value for the LoadBalancer and NodePort service types.
-    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
-    ##
-    # nodePort:
-
-    ## Provide any additional annotations which may be required. This can be used to
-    ## set the LoadBalancer service type to internal only.
-    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
-    ##
-    annotations: {}
-    loadBalancerIP:
-
-  ## Redis slave port
-  port: 6379
-  ## Can be used to specify command line arguments, for example:
-  ##
-  command: "/run.sh"
-  ## Additional Redis configuration for the slave nodes
-  ## ref: https://redis.io/topics/config
-  ##
-  configmap:
-  ## Redis extra flags
-  extraFlags: []
-  ## List of Redis commands to disable
-  disableCommands:
-  - FLUSHDB
-  - FLUSHALL
-
-  ## Redis Slave pod/node affinity/anti-affinity
-  ##
-  affinity: {}
-
-  ## Configure extra options for Redis Slave liveness and readiness probes
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
-  ##
-  livenessProbe:
-    enabled: true
-    initialDelaySeconds: 30
-    periodSeconds: 10
-    timeoutSeconds: 5
-    successThreshold: 1
-    failureThreshold: 5
-  readinessProbe:
-    enabled: true
-    initialDelaySeconds: 5
-    periodSeconds: 10
-    timeoutSeconds: 10
-    successThreshold: 1
-    failureThreshold: 5
-
-  ## Redis slave Resource
-  # resources:
-  #   requests:
-  #     memory: 256Mi
-  #     cpu: 100m
-
-  ## Redis slave selectors and tolerations for pod assignment
-  # nodeSelector: {"beta.kubernetes.io/arch": "amd64"}
-  # tolerations: []
-
-  ## Use an alternate scheduler, e.g. "stork".
-  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
-  ##
-  # schedulerName:
-
-  ## Redis slave pod Annotation and Labels
-  podLabels: {}
-  podAnnotations: {}
-
-  ## Redis slave pod priorityClassName
-  # priorityClassName: {}
-
-  ## Enable persistence using Persistent Volume Claims
-  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-  ##
-  persistence:
-    enabled: true
-    ## The path the volume will be mounted at, useful when using different
-    ## Redis images.
-    path: /data
-    ## The subdirectory of the volume to mount to, useful in dev environments
-    ## and one PV for multiple services.
-    subPath: ""
-    ## redis data Persistent Volume Storage Class
-    ## If defined, storageClassName: <storageClass>
-    ## If set to "-", storageClassName: "", which disables dynamic provisioning
-    ## If undefined (the default) or set to null, no storageClassName spec is
-    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-    ##   GKE, AWS & OpenStack)
-    ##
-    storageClass: rook-ceph-block #changeme
-    accessModes:
-    - ReadWriteOnce
-    size: 8Gi
-
-  ## Update strategy, can be set to RollingUpdate or onDelete by default.
-  ## https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets
-  statefulset:
-    updateStrategy: RollingUpdate
-    ## Partition update strategy
-    ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
-    # rollingUpdatePartition:
-
-## Prometheus Exporter / Metrics
-##
-metrics:
   enabled: true
-
-  image:
-    registry: docker.io
-    repository: bitnami/redis-exporter
-    tag: 1.1.0-debian-9-r16
-    pullPolicy: IfNotPresent
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ##
-    # pullSecrets:
-    #   - myRegistryKeySecretName
-
-  ## Metrics exporter resource requests and limits
-  ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param auth.sentinel Enable password authentication on sentinels too
   ##
-  # resources: {}
-
-  ## Extra arguments for Metrics exporter, for example:
-  ## extraArgs:
-  ##   check-keys: myKey,myOtherKey
-  # extraArgs: {}
-
-  ## Metrics exporter pod priorityClassName
-  # priorityClassName: {}
-  service:
-    type: ClusterIP
-    ## Use serviceLoadBalancerIP to request a specific static IP,
-    ## otherwise leave blank
-    # loadBalancerIP:
-    annotations: {}
-  ## Metrics exporter pod Annotation and Labels
-  podAnnotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9121"
-  # podLabels: {}
-
-  # Enable this if you're using https://github.com/coreos/prometheus-operator
-  serviceMonitor:
-    enabled: false
-    ## Specify a namespace if needed
-    # namespace: monitoring
-    # fallback to the prometheus default unless specified
-    # interval: 10s
-    ## Defaults to what's used if you follow CoreOS [Prometheus Install Instructions](https://github.com/helm/charts/tree/master/stable/prometheus-operator#tldr)
-    ## [Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#prometheus-operator-1)
-    ## [Kube Prometheus Selector Label](https://github.com/helm/charts/tree/master/stable/prometheus-operator#exporters)
-    selector:
-      prometheus: kube-prometheus
-
-##
-## Init containers parameters:
-## volumePermissions: Change the owner of the persist volume mountpoint to RunAsUser:fsGroup
-##
-volumePermissions:
-  enabled: false
-  image:
-    registry: docker.io
-    repository: bitnami/minideb
-    tag: stretch
-    pullPolicy: Always
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ##
-    # pullSecrets:
-    #   - myRegistryKeySecretName
-  resources: {}
-  # resources:
-  #   requests:
-  #     memory: 128Mi
-  #     cpu: 100m
-
-## Redis config file
+  sentinel: false
+  ## @param auth.password Redis&trade; password
+  ## Defaults to a random 10-character alphanumeric string if not set
+  ##
+  password: ""
+  ## @param auth.existingSecret The name of an existing secret with Redis&trade; credentials
+  ## NOTE: When it's set, the previous `auth.password` parameter is ignored
+  ##
+  existingSecret: ""
+  ## @param auth.existingSecretPasswordKey Password key to be retrieved from existing secret
+  ## NOTE: ignored unless `auth.existingSecret` parameter is set
+  ##
+  existingSecretPasswordKey: ""
+  ## @param auth.usePasswordFiles Mount credentials as files instead of using an environment variable
+  ##
+  usePasswordFiles: false
+## @param commonConfiguration [string] Common configuration to be added into the ConfigMap
 ## ref: https://redis.io/topics/config
 ##
-configmap: |-
+commonConfiguration: |-
   # Enable AOF https://redis.io/topics/persistence#append-only-file
   appendonly yes
   # Disable RDB persistence, AOF persistence already enabled.
   save ""
+## @param existingConfigmap The name of an existing ConfigMap with your custom configuration for Redis&trade; nodes
+##
+existingConfigmap: ""
 
-## Sysctl InitContainer
-## used to perform sysctl operation to modify Kernel settings (needed sometimes to avoid warnings)
-sysctlImage:
-  enabled: false
-  command: []
-  registry: docker.io
-  repository: bitnami/minideb
-  tag: stretch
-  pullPolicy: Always
-  ## Optionally specify an array of imagePullSecrets.
-  ## Secrets must be manually created in the namespace.
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+## @section Redis&trade; master configuration parameters
+##
+
+master:
+  ## @param master.configuration Configuration for Redis&trade; master nodes
+  ## ref: https://redis.io/topics/config
   ##
-  # pullSecrets:
-  #   - myRegistryKeySecretName
+  configuration: ""
+  ## @param master.disableCommands Array with Redis&trade; commands to disable on master nodes
+  ## Commands will be completely disabled by renaming each to an empty string.
+  ## ref: https://redis.io/topics/security#disabling-of-specific-commands
+  ##
+  disableCommands:
+    - FLUSHDB
+    - FLUSHALL
+  ## @param master.command Override default container command (useful when using custom images)
+  ##
+  command: []
+  ## @param master.args Override default container args (useful when using custom images)
+  ##
+  args: []
+  ## @param master.preExecCmds Additional commands to run prior to starting Redis&trade; master
+  ##
+  preExecCmds: []
+  ## @param master.extraFlags Array with additional command line flags for Redis&trade; master
+  ## e.g:
+  ## extraFlags:
+  ##  - "--maxmemory-policy volatile-ttl"
+  ##  - "--repl-backlog-size 1024mb"
+  ##
+  extraFlags: []
+  ## @param master.extraEnvVars Array with extra environment variables to add to Redis&trade; master nodes
+  ## e.g:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## @param master.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for Redis&trade; master nodes
+  ##
+  extraEnvVarsCM: ""
+  ## @param master.extraEnvVarsSecret Name of existing Secret containing extra env vars for Redis&trade; master nodes
+  ##
+  extraEnvVarsSecret: ""
+  ## @param master.containerPorts.redis Container port to open on Redis&trade; master nodes
+  ##
+  containerPorts:
+    redis: 6379
+  ## Configure extra options for Redis&trade; containers' liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+  ## @param master.startupProbe.enabled Enable startupProbe on Redis&trade; master nodes
+  ## @param master.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param master.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param master.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param master.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param master.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 20
+    periodSeconds: 5
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 5
+  ## @param master.livenessProbe.enabled Enable livenessProbe on Redis&trade; master nodes
+  ## @param master.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param master.livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param master.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  ## @param master.livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param master.livenessProbe.successThreshold Success threshold for livenessProbe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 20
+    periodSeconds: 5
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 5
+  ## @param master.readinessProbe.enabled Enable readinessProbe on Redis&trade; master nodes
+  ## @param master.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  ## @param master.readinessProbe.periodSeconds Period seconds for readinessProbe
+  ## @param master.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  ## @param master.readinessProbe.failureThreshold Failure threshold for readinessProbe
+  ## @param master.readinessProbe.successThreshold Success threshold for readinessProbe
+  ##
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 20
+    periodSeconds: 5
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 5
+  ## @param master.customStartupProbe Custom startupProbe that overrides the default one
+  ##
+  customStartupProbe: {}
+  ## @param master.customLivenessProbe Custom livenessProbe that overrides the default one
+  ##
+  customLivenessProbe: {}
+  ## @param master.customReadinessProbe Custom readinessProbe that overrides the default one
+  ##
+  customReadinessProbe: {}
+  ## Redis&trade; master resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param master.resources.limits The resources limits for the Redis&trade; master containers
+  ## @param master.resources.requests The requested resources for the Redis&trade; master containers
+  ##
+  resources:
+    limits: {}
+    requests: {}
+  ## Configure Pods Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  ## @param master.podSecurityContext.enabled Enabled Redis&trade; master pods' Security Context
+  ## @param master.podSecurityContext.fsGroup Set Redis&trade; master pod's Security Context fsGroup
+  ##
+  podSecurityContext:
+    enabled: true
+    fsGroup: 1001
+  ## Configure Container Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  ## @param master.containerSecurityContext.enabled Enabled Redis&trade; master containers' Security Context
+  ## @param master.containerSecurityContext.runAsUser Set Redis&trade; master containers' Security Context runAsUser
+  ##
+  containerSecurityContext:
+    enabled: true
+    runAsUser: 1001
+  ## @param master.kind Use either Deployment or StatefulSet (default)
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
+  ##
+  kind: StatefulSet
+  ## @param master.schedulerName Alternate scheduler for Redis&trade; master pods
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  schedulerName: ""
+  ## @param master.updateStrategy.type Redis&trade; master statefulset strategy type
+  ## @skip master.updateStrategy.rollingUpdate
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+  ##
+  updateStrategy:
+    ## StrategyType
+    ## Can be set to RollingUpdate or OnDelete
+    ##
+    type: RollingUpdate
+    rollingUpdate: {}
+  ## @param master.priorityClassName Redis&trade; master pods' priorityClassName
+  ##
+  priorityClassName: ""
+  ## @param master.hostAliases Redis&trade; master pods host aliases
+  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  ##
+  hostAliases: []
+  ## @param master.podLabels Extra labels for Redis&trade; master pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  ##
+  podLabels: {}
+  ## @param master.podAnnotations Annotations for Redis&trade; master pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+  ## @param master.shareProcessNamespace Share a single process namespace between all of the containers in Redis&trade; master pods
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+  ##
+  shareProcessNamespace: false
+  ## @param master.podAffinityPreset Pod affinity preset. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ##
+  podAffinityPreset: ""
+  ## @param master.podAntiAffinityPreset Pod anti-affinity preset. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ##
+  podAntiAffinityPreset: soft
+  ## Node master.affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ##
+  nodeAffinityPreset:
+    ## @param master.nodeAffinityPreset.type Node affinity preset type. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`
+    ##
+    type: ""
+    ## @param master.nodeAffinityPreset.key Node label key to match. Ignored if `master.affinity` is set
+    ##
+    key: ""
+    ## @param master.nodeAffinityPreset.values Node label values to match. Ignored if `master.affinity` is set
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+  ## @param master.affinity Affinity for Redis&trade; master pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## NOTE: `master.podAffinityPreset`, `master.podAntiAffinityPreset`, and `master.nodeAffinityPreset` will be ignored when it's set
+  ##
+  affinity: {}
+  ## @param master.nodeSelector Node labels for Redis&trade; master pods assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+  ## @param master.tolerations Tolerations for Redis&trade; master pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+  ## @param master.topologySpreadConstraints Spread Constraints for Redis&trade; master pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  ## E.g.
+  ## topologySpreadConstraints:
+  ##   - maxSkew: 1
+  ##     topologyKey: node
+  ##     whenUnsatisfiable: DoNotSchedule
+  ##
+  topologySpreadConstraints: {}
+  ## @param master.lifecycleHooks for the Redis&trade; master container(s) to automate configuration before or after startup
+  ##
+  lifecycleHooks: {}
+  ## @param master.extraVolumes Optionally specify extra list of additional volumes for the Redis&trade; master pod(s)
+  ##
+  extraVolumes: []
+  ## @param master.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the Redis&trade; master container(s)
+  ##
+  extraVolumeMounts: []
+  ## @param master.sidecars Add additional sidecar containers to the Redis&trade; master pod(s)
+  ## e.g:
+  ## sidecars:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
+  ##
+  sidecars: []
+  ## @param master.initContainers Add additional init containers to the Redis&trade; master pod(s)
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+  ## e.g:
+  ## initContainers:
+  ##  - name: your-image-name
+  ##    image: your-image
+  ##    imagePullPolicy: Always
+  ##    command: ['sh', '-c', 'echo "hello world"']
+  ##
+  initContainers: []
+  ## Persistence parameters
+  ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    ## @param master.persistence.enabled Enable persistence on Redis&trade; master nodes using Persistent Volume Claims
+    ##
+    enabled: true
+    ## @param master.persistence.medium Provide a medium for `emptyDir` volumes.
+    ##
+    medium: ""
+    ## @param master.persistence.path The path the volume will be mounted at on Redis&trade; master containers
+    ## NOTE: Useful when using different Redis&trade; images
+    ##
+    path: /data
+    ## @param master.persistence.subPath The subdirectory of the volume to mount on Redis&trade; master containers
+    ## NOTE: Useful in dev environments
+    ##
+    subPath: ""
+    ## @param master.persistence.storageClass Persistent Volume storage class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner
+    ##
+    storageClass: "rook-ceph-block" #changeme
+    ## @param master.persistence.accessModes Persistent Volume access modes
+    ##
+    accessModes:
+      - ReadWriteOnce
+    ## @param master.persistence.size Persistent Volume size
+    ##
+    size: 8Gi
+    ## @param master.persistence.annotations Additional custom annotations for the PVC
+    ##
+    annotations: {}
+    ## @param master.persistence.selector Additional labels to match for the PVC
+    ## e.g:
+    ## selector:
+    ##   matchLabels:
+    ##     app: my-app
+    ##
+    selector: {}
+    ## @param master.persistence.dataSource Custom PVC data source
+    dataSource: {}
+    ## @param master.persistence.existingClaim Use a existing PVC which must be created manually before bound
+    ## NOTE: requires master.persistence.enabled: true
+    ##
+    existingClaim: ""
+  ## Redis&trade; master service parameters
+  ##
+  service:
+    ## @param master.service.type Redis&trade; master service type
+    ##
+    type: ClusterIP
+    ## @param master.service.ports.redis Redis&trade; master service port
+    ##
+    ports:
+      redis: 6379
+    ## @param master.service.nodePorts.redis Node port for Redis&trade; master
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    ## NOTE: choose port between <30000-32767>
+    ##
+    nodePorts:
+      redis: ""
+    ## @param master.service.externalTrafficPolicy Redis&trade; master service external traffic policy
+    ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+    ##
+    externalTrafficPolicy: Cluster
+    ## @param master.service.extraPorts Extra ports to expose (normally used with the `sidecar` value)
+    ##
+    extraPorts: []
+    ## @param master.service.clusterIP Redis&trade; master service Cluster IP
+    ##
+    clusterIP: ""
+    ## @param master.service.loadBalancerIP Redis&trade; master service Load Balancer IP
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    loadBalancerIP: ""
+    ## @param master.service.loadBalancerSourceRanges Redis&trade; master service Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ## e.g.
+    ## loadBalancerSourceRanges:
+    ##   - 10.10.10.0/24
+    ##
+    loadBalancerSourceRanges: []
+    ## @param master.service.annotations Additional custom annotations for Redis&trade; master service
+    ##
+    annotations: {}
+  ## @param master.terminationGracePeriodSeconds Integer setting the termination grace period for the redis-master pods
+  ##
+  terminationGracePeriodSeconds: 30
+
+## @section Redis&trade; replicas configuration parameters
+##
+
+replica:
+  ## @param replica.replicaCount Number of Redis&trade; replicas to deploy
+  ##
+  replicaCount: 3
+  ## @param replica.configuration Configuration for Redis&trade; replicas nodes
+  ## ref: https://redis.io/topics/config
+  ##
+  configuration: ""
+  ## @param replica.disableCommands Array with Redis&trade; commands to disable on replicas nodes
+  ## Commands will be completely disabled by renaming each to an empty string.
+  ## ref: https://redis.io/topics/security#disabling-of-specific-commands
+  ##
+  disableCommands:
+    - FLUSHDB
+    - FLUSHALL
+  ## @param replica.command Override default container command (useful when using custom images)
+  ##
+  command: []
+  ## @param replica.args Override default container args (useful when using custom images)
+  ##
+  args: []
+  ## @param replica.preExecCmds Additional commands to run prior to starting Redis&trade; replicas
+  ##
+  preExecCmds: []
+  ## @param replica.extraFlags Array with additional command line flags for Redis&trade; replicas
+  ## e.g:
+  ## extraFlags:
+  ##  - "--maxmemory-policy volatile-ttl"
+  ##  - "--repl-backlog-size 1024mb"
+  ##
+  extraFlags: []
+  ## @param replica.extraEnvVars Array with extra environment variables to add to Redis&trade; replicas nodes
+  ## e.g:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## @param replica.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for Redis&trade; replicas nodes
+  ##
+  extraEnvVarsCM: ""
+  ## @param replica.extraEnvVarsSecret Name of existing Secret containing extra env vars for Redis&trade; replicas nodes
+  ##
+  extraEnvVarsSecret: ""
+  ## @param replica.externalMaster.enabled Use external master for bootstrapping
+  ## @param replica.externalMaster.host External master host to bootstrap from
+  ## @param replica.externalMaster.port Port for Redis service external master host
+  ##
+  externalMaster:
+    enabled: false
+    host: ""
+    port: 6379
+  ## @param replica.containerPorts.redis Container port to open on Redis&trade; replicas nodes
+  ##
+  containerPorts:
+    redis: 6379
+  ## Configure extra options for Redis&trade; containers' liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+  ## @param replica.startupProbe.enabled Enable startupProbe on Redis&trade; replicas nodes
+  ## @param replica.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param replica.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param replica.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param replica.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param replica.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 20
+    periodSeconds: 5
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 5
+  ## @param replica.livenessProbe.enabled Enable livenessProbe on Redis&trade; replicas nodes
+  ## @param replica.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param replica.livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param replica.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  ## @param replica.livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param replica.livenessProbe.successThreshold Success threshold for livenessProbe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 20
+    periodSeconds: 5
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 5
+  ## @param replica.readinessProbe.enabled Enable readinessProbe on Redis&trade; replicas nodes
+  ## @param replica.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  ## @param replica.readinessProbe.periodSeconds Period seconds for readinessProbe
+  ## @param replica.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  ## @param replica.readinessProbe.failureThreshold Failure threshold for readinessProbe
+  ## @param replica.readinessProbe.successThreshold Success threshold for readinessProbe
+  ##
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 20
+    periodSeconds: 5
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 5
+  ## @param replica.customStartupProbe Custom startupProbe that overrides the default one
+  ##
+  customStartupProbe: {}
+  ## @param replica.customLivenessProbe Custom livenessProbe that overrides the default one
+  ##
+  customLivenessProbe: {}
+  ## @param replica.customReadinessProbe Custom readinessProbe that overrides the default one
+  ##
+  customReadinessProbe: {}
+  ## Redis&trade; replicas resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param replica.resources.limits The resources limits for the Redis&trade; replicas containers
+  ## @param replica.resources.requests The requested resources for the Redis&trade; replicas containers
+  ##
+  resources:
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    limits: {}
+    #   cpu: 250m
+    #   memory: 256Mi
+    requests: {}
+    #   cpu: 250m
+    #   memory: 256Mi
+  ## Configure Pods Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  ## @param replica.podSecurityContext.enabled Enabled Redis&trade; replicas pods' Security Context
+  ## @param replica.podSecurityContext.fsGroup Set Redis&trade; replicas pod's Security Context fsGroup
+  ##
+  podSecurityContext:
+    enabled: true
+    fsGroup: 1001
+  ## Configure Container Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  ## @param replica.containerSecurityContext.enabled Enabled Redis&trade; replicas containers' Security Context
+  ## @param replica.containerSecurityContext.runAsUser Set Redis&trade; replicas containers' Security Context runAsUser
+  ##
+  containerSecurityContext:
+    enabled: true
+    runAsUser: 1001
+  ## @param replica.schedulerName Alternate scheduler for Redis&trade; replicas pods
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  schedulerName: ""
+  ## @param replica.updateStrategy.type Redis&trade; replicas statefulset strategy type
+  ## @skip replica.updateStrategy.rollingUpdate
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+  ##
+  updateStrategy:
+    ## StrategyType
+    ## Can be set to RollingUpdate or OnDelete
+    ##
+    type: RollingUpdate
+    rollingUpdate: {}
+  ## @param replica.priorityClassName Redis&trade; replicas pods' priorityClassName
+  ##
+  priorityClassName: ""
+  ## @param replica.podManagementPolicy podManagementPolicy to manage scaling operation of %%MAIN_CONTAINER_NAME%% pods
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
+  ##
+  podManagementPolicy: ""
+  ## @param replica.hostAliases Redis&trade; replicas pods host aliases
+  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  ##
+  hostAliases: []
+  ## @param replica.podLabels Extra labels for Redis&trade; replicas pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  ##
+  podLabels: {}
+  ## @param replica.podAnnotations Annotations for Redis&trade; replicas pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+  ## @param replica.shareProcessNamespace Share a single process namespace between all of the containers in Redis&trade; replicas pods
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+  ##
+  shareProcessNamespace: false
+  ## @param replica.podAffinityPreset Pod affinity preset. Ignored if `replica.affinity` is set. Allowed values: `soft` or `hard`
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ##
+  podAffinityPreset: ""
+  ## @param replica.podAntiAffinityPreset Pod anti-affinity preset. Ignored if `replica.affinity` is set. Allowed values: `soft` or `hard`
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ##
+  podAntiAffinityPreset: soft
+  ## Node affinity preset
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ##
+  nodeAffinityPreset:
+    ## @param replica.nodeAffinityPreset.type Node affinity preset type. Ignored if `replica.affinity` is set. Allowed values: `soft` or `hard`
+    ##
+    type: ""
+    ## @param replica.nodeAffinityPreset.key Node label key to match. Ignored if `replica.affinity` is set
+    ##
+    key: ""
+    ## @param replica.nodeAffinityPreset.values Node label values to match. Ignored if `replica.affinity` is set
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
+  ## @param replica.affinity Affinity for Redis&trade; replicas pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## NOTE: `replica.podAffinityPreset`, `replica.podAntiAffinityPreset`, and `replica.nodeAffinityPreset` will be ignored when it's set
+  ##
+  affinity: {}
+  ## @param replica.nodeSelector Node labels for Redis&trade; replicas pods assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+  ## @param replica.tolerations Tolerations for Redis&trade; replicas pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+  ## @param replica.topologySpreadConstraints Spread Constraints for Redis&trade; replicas pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  ## E.g.
+  ## topologySpreadConstraints:
+  ##   - maxSkew: 1
+  ##     topologyKey: node
+  ##     whenUnsatisfiable: DoNotSchedule
+  ##
+  topologySpreadConstraints: {}
+  ## @param replica.lifecycleHooks for the Redis&trade; replica container(s) to automate configuration before or after startup
+  ##
+  lifecycleHooks: {}
+  ## @param replica.extraVolumes Optionally specify extra list of additional volumes for the Redis&trade; replicas pod(s)
+  ##
+  extraVolumes: []
+  ## @param replica.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the Redis&trade; replicas container(s)
+  ##
+  extraVolumeMounts: []
+  ## @param replica.sidecars Add additional sidecar containers to the Redis&trade; replicas pod(s)
+  ## e.g:
+  ## sidecars:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
+  ##
+  sidecars: []
+  ## @param replica.initContainers Add additional init containers to the Redis&trade; replicas pod(s)
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+  ## e.g:
+  ## initContainers:
+  ##  - name: your-image-name
+  ##    image: your-image
+  ##    imagePullPolicy: Always
+  ##    command: ['sh', '-c', 'echo "hello world"']
+  ##
+  initContainers: []
+  ## Persistence Parameters
+  ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    ## @param replica.persistence.enabled Enable persistence on Redis&trade; replicas nodes using Persistent Volume Claims
+    ##
+    enabled: true
+    ## @param replica.persistence.medium Provide a medium for `emptyDir` volumes.
+    ##
+    medium: ""
+    ## @param replica.persistence.path The path the volume will be mounted at on Redis&trade; replicas containers
+    ## NOTE: Useful when using different Redis&trade; images
+    ##
+    path: /data
+    ## @param replica.persistence.subPath The subdirectory of the volume to mount on Redis&trade; replicas containers
+    ## NOTE: Useful in dev environments
+    ##
+    subPath: ""
+    ## @param replica.persistence.storageClass Persistent Volume storage class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner
+    ##
+    storageClass: "rook-ceph-block" #changeme
+    ## @param replica.persistence.accessModes Persistent Volume access modes
+    ##
+    accessModes:
+      - ReadWriteOnce
+    ## @param replica.persistence.size Persistent Volume size
+    ##
+    size: 8Gi
+    ## @param replica.persistence.annotations Additional custom annotations for the PVC
+    ##
+    annotations: {}
+    ## @param replica.persistence.selector Additional labels to match for the PVC
+    ## e.g:
+    ## selector:
+    ##   matchLabels:
+    ##     app: my-app
+    ##
+    selector: {}
+    ## @param replica.persistence.dataSource Custom PVC data source
+    dataSource: {}
+  ## Redis&trade; replicas service parameters
+  ##
+  service:
+    ## @param replica.service.type Redis&trade; replicas service type
+    ##
+    type: ClusterIP
+    ## @param replica.service.ports.redis Redis&trade; replicas service port
+    ##
+    ports:
+      redis: 6379
+    ## @param replica.service.nodePorts.redis Node port for Redis&trade; replicas
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    ## NOTE: choose port between <30000-32767>
+    ##
+    nodePorts:
+      redis: ""
+    ## @param replica.service.externalTrafficPolicy Redis&trade; replicas service external traffic policy
+    ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+    ##
+    externalTrafficPolicy: Cluster
+    ## @param replica.service.extraPorts Extra ports to expose (normally used with the `sidecar` value)
+    ##
+    extraPorts: []
+    ## @param replica.service.clusterIP Redis&trade; replicas service Cluster IP
+    ##
+    clusterIP: ""
+    ## @param replica.service.loadBalancerIP Redis&trade; replicas service Load Balancer IP
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    loadBalancerIP: ""
+    ## @param replica.service.loadBalancerSourceRanges Redis&trade; replicas service Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ## e.g.
+    ## loadBalancerSourceRanges:
+    ##   - 10.10.10.0/24
+    ##
+    loadBalancerSourceRanges: []
+    ## @param replica.service.annotations Additional custom annotations for Redis&trade; replicas service
+    ##
+    annotations: {}
+  ## @param replica.terminationGracePeriodSeconds Integer setting the termination grace period for the redis-replicas pods
+  ##
+  terminationGracePeriodSeconds: 30
+  ## Autoscaling configuration
+  ##
+  autoscaling:
+    ## @param replica.autoscaling.enabled Enable replica autoscaling settings
+    ##
+    enabled: false
+    ## @param replica.autoscaling.minReplicas Minimum replicas for the pod autoscaling
+    ##
+    minReplicas: 1
+    ## @param replica.autoscaling.maxReplicas Maximum replicas for the pod autoscaling
+    ##
+    maxReplicas: 11
+    ## @param replica.autoscaling.targetCPU Percentage of CPU to consider when autoscaling
+    ##
+    targetCPU: ""
+    ## @param replica.autoscaling.targetMemory Percentage of Memory to consider when autoscaling
+    ##
+    targetMemory: ""
+
+## @section Redis&trade; Sentinel configuration parameters
+##
+
+sentinel:
+  ## @param sentinel.enabled Use Redis&trade; Sentinel on Redis&trade; pods.
+  ## IMPORTANT: this will disable the master and replicas services and
+  ## create a single Redis&trade; service exposing both the Redis and Sentinel ports
+  ##
+  enabled: false
+  ## Bitnami Redis&trade; Sentinel image version
+  ## ref: https://hub.docker.com/r/bitnami/redis-sentinel/tags/
+  ## @param sentinel.image.registry Redis&trade; Sentinel image registry
+  ## @param sentinel.image.repository Redis&trade; Sentinel image repository
+  ## @param sentinel.image.tag Redis&trade; Sentinel image tag (immutable tags are recommended)
+  ## @param sentinel.image.pullPolicy Redis&trade; Sentinel image pull policy
+  ## @param sentinel.image.pullSecrets Redis&trade; Sentinel image pull secrets
+  ## @param sentinel.image.debug Enable image debug mode
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/redis-sentinel
+    tag: 6.2.6-debian-10-r140
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+    ## Enable debug mode
+    ##
+    debug: false
+  ## @param sentinel.masterSet Master set name
+  ##
+  masterSet: mymaster
+  ## @param sentinel.quorum Sentinel Quorum
+  ##
+  quorum: 2
+  ## @param sentinel.automateClusterRecovery Automate cluster recovery in cases where the last replica is not considered a good replica and Sentinel won't automatically failover to it.
+  ## This also prevents any new replica from starting until the last remaining replica is elected as master to guarantee that it is the one to be elected by Sentinel, and not a newly started replica with no data.
+  ## NOTE: This feature requires a "downAfterMilliseconds" value less or equal to 2000.
+  ##
+  automateClusterRecovery: false
+  ## Sentinel timing restrictions
+  ## @param sentinel.downAfterMilliseconds Timeout for detecting a Redis&trade; node is down
+  ## @param sentinel.failoverTimeout Timeout for performing a election failover
+  ##
+  downAfterMilliseconds: 60000
+  failoverTimeout: 18000
+  ## @param sentinel.parallelSyncs Number of replicas that can be reconfigured in parallel to use the new master after a failover
+  ##
+  parallelSyncs: 1
+  ## @param sentinel.configuration Configuration for Redis&trade; Sentinel nodes
+  ## ref: https://redis.io/topics/sentinel
+  ##
+  configuration: ""
+  ## @param sentinel.command Override default container command (useful when using custom images)
+  ##
+  command: []
+  ## @param sentinel.args Override default container args (useful when using custom images)
+  ##
+  args: []
+  ## @param sentinel.preExecCmds Additional commands to run prior to starting Redis&trade; Sentinel
+  ##
+  preExecCmds: []
+  ## @param sentinel.extraEnvVars Array with extra environment variables to add to Redis&trade; Sentinel nodes
+  ## e.g:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## @param sentinel.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for Redis&trade; Sentinel nodes
+  ##
+  extraEnvVarsCM: ""
+  ## @param sentinel.extraEnvVarsSecret Name of existing Secret containing extra env vars for Redis&trade; Sentinel nodes
+  ##
+  extraEnvVarsSecret: ""
+  ## @param sentinel.externalMaster.enabled Use external master for bootstrapping
+  ## @param sentinel.externalMaster.host External master host to bootstrap from
+  ## @param sentinel.externalMaster.port Port for Redis service external master host
+  externalMaster:
+    enabled: false
+    host: ""
+    port: 6379
+  ## @param sentinel.containerPorts.sentinel Container port to open on Redis&trade; Sentinel nodes
+  ##
+  containerPorts:
+    sentinel: 26379
+  ## Configure extra options for Redis&trade; containers' liveness and readiness probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+  ## @param sentinel.startupProbe.enabled Enable startupProbe on Redis&trade; Sentinel nodes
+  ## @param sentinel.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param sentinel.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param sentinel.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param sentinel.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param sentinel.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 20
+    periodSeconds: 5
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 5
+  ## @param sentinel.livenessProbe.enabled Enable livenessProbe on Redis&trade; Sentinel nodes
+  ## @param sentinel.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param sentinel.livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param sentinel.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  ## @param sentinel.livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param sentinel.livenessProbe.successThreshold Success threshold for livenessProbe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 20
+    periodSeconds: 5
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 5
+  ## @param sentinel.readinessProbe.enabled Enable readinessProbe on Redis&trade; Sentinel nodes
+  ## @param sentinel.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  ## @param sentinel.readinessProbe.periodSeconds Period seconds for readinessProbe
+  ## @param sentinel.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  ## @param sentinel.readinessProbe.failureThreshold Failure threshold for readinessProbe
+  ## @param sentinel.readinessProbe.successThreshold Success threshold for readinessProbe
+  ##
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 20
+    periodSeconds: 5
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 5
+  ## @param sentinel.customStartupProbe Custom startupProbe that overrides the default one
+  ##
+  customStartupProbe: {}
+  ## @param sentinel.customLivenessProbe Custom livenessProbe that overrides the default one
+  ##
+  customLivenessProbe: {}
+  ## @param sentinel.customReadinessProbe Custom readinessProbe that overrides the default one
+  ##
+  customReadinessProbe: {}
+  ## Redis&trade; Sentinel resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param sentinel.resources.limits The resources limits for the Redis&trade; Sentinel containers
+  ## @param sentinel.resources.requests The requested resources for the Redis&trade; Sentinel containers
+  ##
+  resources:
+    limits: {}
+    requests: {}
+  ## Configure Container Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  ## @param sentinel.containerSecurityContext.enabled Enabled Redis&trade; Sentinel containers' Security Context
+  ## @param sentinel.containerSecurityContext.runAsUser Set Redis&trade; Sentinel containers' Security Context runAsUser
+  ##
+  containerSecurityContext:
+    enabled: true
+    runAsUser: 1001
+  ## @param sentinel.lifecycleHooks for the Redis&trade; sentinel container(s) to automate configuration before or after startup
+  ##
+  lifecycleHooks: {}
+  ## @param sentinel.extraVolumes Optionally specify extra list of additional volumes for the Redis&trade; Sentinel
+  ##
+  extraVolumes: []
+  ## @param sentinel.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the Redis&trade; Sentinel container(s)
+  ##
+  extraVolumeMounts: []
+  ## Redis&trade; Sentinel service parameters
+  ##
+  service:
+    ## @param sentinel.service.type Redis&trade; Sentinel service type
+    ##
+    type: ClusterIP
+    ## @param sentinel.service.ports.redis Redis&trade; service port for Redis&trade;
+    ## @param sentinel.service.ports.sentinel Redis&trade; service port for Redis&trade; Sentinel
+    ports:
+      redis: 6379
+      sentinel: 26379
+    ## @param sentinel.service.nodePorts.redis Node port for Redis&trade;
+    ## @param sentinel.service.nodePorts.sentinel Node port for Sentinel
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    ## NOTE: choose port between <30000-32767>
+    ## NOTE: By leaving these values blank, they will be generated by ports-configmap
+    ##       If setting manually, please leave at least replica.replicaCount + 1 in between sentinel.service.nodePorts.redis and sentinel.service.nodePorts.sentinel to take into account the ports that will be created while incrementing that base port
+    ##
+    nodePorts:
+      redis: ""
+      sentinel: ""
+    ## @param sentinel.service.externalTrafficPolicy Redis&trade; Sentinel service external traffic policy
+    ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+    ##
+    externalTrafficPolicy: Cluster
+    ## @param sentinel.service.extraPorts Extra ports to expose (normally used with the `sidecar` value)
+    ##
+    extraPorts: []
+    ## @param sentinel.service.clusterIP Redis&trade; Sentinel service Cluster IP
+    ##
+    clusterIP: ""
+    ## @param sentinel.service.loadBalancerIP Redis&trade; Sentinel service Load Balancer IP
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    loadBalancerIP: ""
+    ## @param sentinel.service.loadBalancerSourceRanges Redis&trade; Sentinel service Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ## e.g.
+    ## loadBalancerSourceRanges:
+    ##   - 10.10.10.0/24
+    ##
+    loadBalancerSourceRanges: []
+    ## @param sentinel.service.annotations Additional custom annotations for Redis&trade; Sentinel service
+    ##
+    annotations: {}
+  ## @param sentinel.terminationGracePeriodSeconds Integer setting the termination grace period for the redis-node pods
+  ##
+  terminationGracePeriodSeconds: 30
+
+## @section Other Parameters
+##
+
+## Network Policy configuration
+## ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+##
+networkPolicy:
+  ## @param networkPolicy.enabled Enable creation of NetworkPolicy resources
+  ##
+  enabled: false
+  ## @param networkPolicy.allowExternal Don't require client label for connections
+  ## When set to false, only pods with the correct client label will have network access to the ports
+  ## Redis&trade; is listening on. When true, Redis&trade; will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  allowExternal: true
+  ## @param networkPolicy.extraIngress Add extra ingress rules to the NetworkPolicy
+  ## e.g:
+  ## extraIngress:
+  ##   - ports:
+  ##       - port: 1234
+  ##     from:
+  ##       - podSelector:
+  ##           - matchLabels:
+  ##               - role: frontend
+  ##       - podSelector:
+  ##           - matchExpressions:
+  ##               - key: role
+  ##                 operator: In
+  ##                 values:
+  ##                   - frontend
+  ##
+  extraIngress: []
+  ## @param networkPolicy.extraEgress Add extra ingress rules to the NetworkPolicy
+  ## e.g:
+  ## extraEgress:
+  ##   - ports:
+  ##       - port: 1234
+  ##     to:
+  ##       - podSelector:
+  ##           - matchLabels:
+  ##               - role: frontend
+  ##       - podSelector:
+  ##           - matchExpressions:
+  ##               - key: role
+  ##                 operator: In
+  ##                 values:
+  ##                   - frontend
+  ##
+  extraEgress: []
+  ## @param networkPolicy.ingressNSMatchLabels Labels to match to allow traffic from other namespaces
+  ## @param networkPolicy.ingressNSPodMatchLabels Pod labels to match to allow traffic from other namespaces
+  ##
+  ingressNSMatchLabels: {}
+  ingressNSPodMatchLabels: {}
+## PodSecurityPolicy configuration
+## ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+##
+podSecurityPolicy:
+  ## @param podSecurityPolicy.create Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later
+  ##
+  create: false
+  ## @param podSecurityPolicy.enabled Enable PodSecurityPolicy's RBAC rules
+  ##
+  enabled: false
+## RBAC configuration
+##
+rbac:
+  ## @param rbac.create Specifies whether RBAC resources should be created
+  ##
+  create: false
+  ## @param rbac.rules Custom RBAC rules to set
+  ## e.g:
+  ## rules:
+  ##   - apiGroups:
+  ##       - ""
+  ##     resources:
+  ##       - pods
+  ##     verbs:
+  ##       - get
+  ##       - list
+  ##
+  rules: []
+## ServiceAccount configuration
+##
+serviceAccount:
+  ## @param serviceAccount.create Specifies whether a ServiceAccount should be created
+  ##
+  create: false
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the common.names.fullname template
+  ##
+  name: ""
+  ## @param serviceAccount.automountServiceAccountToken Whether to auto mount the service account token
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server
+  ##
+  automountServiceAccountToken: true
+  ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
+  ##
+  annotations: {}
+## Redis&trade; Pod Disruption Budget configuration
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+##
+pdb:
+  ## @param pdb.create Specifies whether a PodDisruptionBudget should be created
+  ##
+  create: false
+  ## @param pdb.minAvailable Min number of pods that must still be available after the eviction
+  ##
+  minAvailable: 1
+  ## @param pdb.maxUnavailable Max number of pods that can be unavailable after the eviction
+  ##
+  maxUnavailable: ""
+## TLS configuration
+##
+tls:
+  ## @param tls.enabled Enable TLS traffic
+  ##
+  enabled: false
+  ## @param tls.authClients Require clients to authenticate
+  ##
+  authClients: true
+  ## @param tls.autoGenerated Enable autogenerated certificates
+  ##
+  autoGenerated: false
+  ## @param tls.existingSecret The name of the existing secret that contains the TLS certificates
+  ##
+  existingSecret: ""
+  ## @param tls.certificatesSecret DEPRECATED. Use existingSecret instead.
+  ##
+  certificatesSecret: ""
+  ## @param tls.certFilename Certificate filename
+  ##
+  certFilename: ""
+  ## @param tls.certKeyFilename Certificate Key filename
+  ##
+  certKeyFilename: ""
+  ## @param tls.certCAFilename CA Certificate filename
+  ##
+  certCAFilename: ""
+  ## @param tls.dhParamsFilename File containing DH params (in order to support DH based ciphers)
+  ##
+  dhParamsFilename: ""
+
+## @section Metrics Parameters
+##
+
+metrics:
+  ## @param metrics.enabled Start a sidecar prometheus exporter to expose Redis&trade; metrics
+  ##
+  enabled: true
+  ## Bitnami Redis&trade; Exporter image
+  ## ref: https://hub.docker.com/r/bitnami/redis-exporter/tags/
+  ## @param metrics.image.registry Redis&trade; Exporter image registry
+  ## @param metrics.image.repository Redis&trade; Exporter image repository
+  ## @param metrics.image.tag Redis&trade; Redis&trade; Exporter image tag (immutable tags are recommended)
+  ## @param metrics.image.pullPolicy Redis&trade; Exporter image pull policy
+  ## @param metrics.image.pullSecrets Redis&trade; Exporter image pull secrets
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/redis-exporter
+    tag: 1.35.1-debian-10-r12
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  ## @param metrics.command Override default metrics container init command (useful when using custom images)
+  ##
+  command: []
+  ## @param metrics.redisTargetHost A way to specify an alternative Redis&trade; hostname
+  ## Useful for certificate CN/SAN matching
+  ##
+  redisTargetHost: "localhost"
+  ## @param metrics.extraArgs Extra arguments for Redis&trade; exporter, for example:
+  ## e.g.:
+  ## extraArgs:
+  ##   check-keys: myKey,myOtherKey
+  ##
+  extraArgs: {}
+  ## Configure Container Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  ## @param metrics.containerSecurityContext.enabled Enabled Redis&trade; exporter containers' Security Context
+  ## @param metrics.containerSecurityContext.runAsUser Set Redis&trade; exporter containers' Security Context runAsUser
+  ##
+  containerSecurityContext:
+    enabled: true
+    runAsUser: 1001
+  ## @param metrics.extraVolumes Optionally specify extra list of additional volumes for the Redis&trade; metrics sidecar
+  ##
+  extraVolumes: []
+  ## @param metrics.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the Redis&trade; metrics sidecar
+  ##
+  extraVolumeMounts: []
+  ## Redis&trade; exporter resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param metrics.resources.limits The resources limits for the Redis&trade; exporter container
+  ## @param metrics.resources.requests The requested resources for the Redis&trade; exporter container
+  ##
+  resources:
+    limits: {}
+    requests: {}
+  ## @param metrics.podLabels Extra labels for Redis&trade; exporter pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  ##
+  podLabels: {}
+  ## @param metrics.podAnnotations [object] Annotations for Redis&trade; exporter pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9121"
+  ## Redis&trade; exporter service parameters
+  ##
+  service:
+    ## @param metrics.service.type Redis&trade; exporter service type
+    ##
+    type: ClusterIP
+    ## @param metrics.service.port Redis&trade; exporter service port
+    ##
+    port: 9121
+    ## @param metrics.service.externalTrafficPolicy Redis&trade; exporter service external traffic policy
+    ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+    ##
+    externalTrafficPolicy: Cluster
+    ## @param metrics.service.extraPorts Extra ports to expose (normally used with the `sidecar` value)
+    ##
+    extraPorts: []
+    ## @param metrics.service.loadBalancerIP Redis&trade; exporter service Load Balancer IP
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+    ##
+    loadBalancerIP: ""
+    ## @param metrics.service.loadBalancerSourceRanges Redis&trade; exporter service Load Balancer sources
+    ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ## e.g.
+    ## loadBalancerSourceRanges:
+    ##   - 10.10.10.0/24
+    ##
+    loadBalancerSourceRanges: []
+    ## @param metrics.service.annotations Additional custom annotations for Redis&trade; exporter service
+    ##
+    annotations: {}
+  ## Prometheus Service Monitor
+  ## ref: https://github.com/coreos/prometheus-operator
+  ##      https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+  ##
+  serviceMonitor:
+    ## @param metrics.serviceMonitor.enabled Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator
+    ##
+    enabled: false
+    ## @param metrics.serviceMonitor.namespace The namespace in which the ServiceMonitor will be created
+    ##
+    namespace: ""
+    ## @param metrics.serviceMonitor.interval The interval at which metrics should be scraped
+    ##
+    interval: 30s
+    ## @param metrics.serviceMonitor.scrapeTimeout The timeout after which the scrape is ended
+    ##
+    scrapeTimeout: ""
+    ## @param metrics.serviceMonitor.relabellings Metrics RelabelConfigs to apply to samples before scraping.
+    ##
+    relabellings: []
+    ## @param metrics.serviceMonitor.metricRelabelings Metrics RelabelConfigs to apply to samples before ingestion.
+    ##
+    metricRelabelings: []
+    ## @param metrics.serviceMonitor.honorLabels Specify honorLabels parameter to add the scrape endpoint
+    ##
+    honorLabels: false
+    ## @param metrics.serviceMonitor.additionalLabels Additional labels that can be used so ServiceMonitor resource(s) can be discovered by Prometheus
+    ##
+    additionalLabels: {}
+  ## Custom PrometheusRule to be defined
+  ## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
+  ##
+  prometheusRule:
+    ## @param metrics.prometheusRule.enabled Create a custom prometheusRule Resource for scraping metrics using PrometheusOperator
+    ##
+    enabled: false
+    ## @param metrics.prometheusRule.namespace The namespace in which the prometheusRule will be created
+    ##
+    namespace: ""
+    ## @param metrics.prometheusRule.additionalLabels Additional labels for the prometheusRule
+    ##
+    additionalLabels: {}
+    ## @param metrics.prometheusRule.rules Custom Prometheus rules
+    ## e.g:
+    ## rules:
+    ##   - alert: RedisDown
+    ##     expr: redis_up{service="{{ template "common.names.fullname" . }}-metrics"} == 0
+    ##     for: 2m
+    ##     labels:
+    ##       severity: error
+    ##     annotations:
+    ##       summary: Redis&trade; instance {{ "{{ $labels.instance }}" }} down
+    ##       description: Redis&trade; instance {{ "{{ $labels.instance }}" }} is down
+    ##    - alert: RedisMemoryHigh
+    ##      expr: >
+    ##        redis_memory_used_bytes{service="{{ template "common.names.fullname" . }}-metrics"} * 100
+    ##        /
+    ##        redis_memory_max_bytes{service="{{ template "common.names.fullname" . }}-metrics"}
+    ##        > 90
+    ##      for: 2m
+    ##      labels:
+    ##        severity: error
+    ##      annotations:
+    ##        summary: Redis&trade; instance {{ "{{ $labels.instance }}" }} is using too much memory
+    ##        description: |
+    ##          Redis&trade; instance {{ "{{ $labels.instance }}" }} is using {{ "{{ $value }}" }}% of its available memory.
+    ##    - alert: RedisKeyEviction
+    ##      expr: |
+    ##        increase(redis_evicted_keys_total{service="{{ template "common.names.fullname" . }}-metrics"}[5m]) > 0
+    ##      for: 1s
+    ##      labels:
+    ##        severity: error
+    ##      annotations:
+    ##        summary: Redis&trade; instance {{ "{{ $labels.instance }}" }} has evicted keys
+    ##        description: |
+    ##          Redis&trade; instance {{ "{{ $labels.instance }}" }} has evicted {{ "{{ $value }}" }} keys in the last 5 minutes.
+    ##
+    rules: []
+
+## @section Init Container Parameters
+##
+
+## 'volumePermissions' init container parameters
+## Changes the owner and group of the persistent volume mount point to runAsUser:fsGroup values
+##   based on the *podSecurityContext/*containerSecurityContext parameters
+##
+volumePermissions:
+  ## @param volumePermissions.enabled Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`
+  ##
+  enabled: false
+  ## Bitnami Shell image
+  ## ref: https://hub.docker.com/r/bitnami/bitnami-shell/tags/
+  ## @param volumePermissions.image.registry Bitnami Shell image registry
+  ## @param volumePermissions.image.repository Bitnami Shell image repository
+  ## @param volumePermissions.image.tag Bitnami Shell image tag (immutable tags are recommended)
+  ## @param volumePermissions.image.pullPolicy Bitnami Shell image pull policy
+  ## @param volumePermissions.image.pullSecrets Bitnami Shell image pull secrets
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/bitnami-shell
+    tag: 10-debian-10-r351
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  ## Init container's resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param volumePermissions.resources.limits The resources limits for the init container
+  ## @param volumePermissions.resources.requests The requested resources for the init container
+  ##
+  resources:
+    limits: {}
+    requests: {}
+  ## Init container Container Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param volumePermissions.containerSecurityContext.runAsUser Set init container's Security Context runAsUser
+  ## NOTE: when runAsUser is set to special value "auto", init container will try to chown the
+  ##   data folder to auto-determined user&group, using commands: `id -u`:`id -G | cut -d" " -f2`
+  ##   "auto" is especially useful for OpenShift which has scc with dynamic user ids (and 0 is not allowed)
+  ##
+  containerSecurityContext:
+    runAsUser: 0
+
+## init-sysctl container parameters
+## used to perform sysctl operation to modify Kernel settings (needed sometimes to avoid warnings)
+##
+sysctl:
+  ## @param sysctl.enabled Enable init container to modify Kernel settings
+  ##
+  enabled: false
+  ## Bitnami Shell image
+  ## ref: https://hub.docker.com/r/bitnami/bitnami-shell/tags/
+  ## @param sysctl.image.registry Bitnami Shell image registry
+  ## @param sysctl.image.repository Bitnami Shell image repository
+  ## @param sysctl.image.tag Bitnami Shell image tag (immutable tags are recommended)
+  ## @param sysctl.image.pullPolicy Bitnami Shell image pull policy
+  ## @param sysctl.image.pullSecrets Bitnami Shell image pull secrets
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/bitnami-shell
+    tag: 10-debian-10-r351
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  ## @param sysctl.command Override default init-sysctl container command (useful when using custom images)
+  ##
+  command: []
+  ## @param sysctl.mountHostSys Mount the host `/sys` folder to `/host-sys`
+  ##
   mountHostSys: false
-  resources: {}
-  # resources:
-  #   requests:
-  #     memory: 128Mi
-  #     cpu: 100m
+  ## Init container's resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param sysctl.resources.limits The resources limits for the init container
+  ## @param sysctl.resources.requests The requested resources for the init container
+  ##
+  resources:
+    limits: {}
+    requests: {}
+
+## @section useExternalDNS Parameters
+##
+## @param useExternalDNS.enabled Enable various syntax that would enable external-dns to work.  Note this requires a working installation of `external-dns` to be usable.
+## @param useExternalDNS.additionalAnnotations Extra annotations to be utilized when `external-dns` is enabled.
+## @param useExternalDNS.annotationKey The annotation key utilized when `external-dns` is enabled.
+## @param useExternalDNS.suffix The DNS suffix utilized when `external-dns` is enabled.  Note that we prepend the suffix with the full name of the release.
+##
+useExternalDNS:
+  enabled: false
+  suffix: ""
+  annotationKey: external-dns.alpha.kubernetes.io/
+  additionalAnnotations: {}

--- a/sso-saml2-configmap.yaml
+++ b/sso-saml2-configmap.yaml
@@ -7,4 +7,4 @@ kind: ConfigMap
 metadata:
   creationTimestamp: null
   name: sso-saml2-xml
-  namespace: netbox
+  namespace: netbox-community

--- a/sso-saml2-configmap.yaml
+++ b/sso-saml2-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  sso-saml2-metadata.xml: |
+    # Just a template. Replace content with saml2 metadata of your SSO solution, if applicable.
+    #changeme
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: sso-saml2-xml
+  namespace: netbox

--- a/sso-service-ingress.yaml
+++ b/sso-service-ingress.yaml
@@ -1,0 +1,77 @@
+### SSO service definitions
+apiVersion: v1
+kind: Service
+metadata:
+  name: netbox-sso
+  namespace: netbox-community
+  labels:
+    k8s-app: netbox
+spec:
+  ports:
+  - port: 80
+    targetPort: http
+  selector:
+    k8s-app: netbox
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: netbox-sso-login
+  namespace: netbox-community
+  labels:
+    k8s-app: netbox
+spec:
+  ports:
+  - port: 80
+    targetPort: http
+  selector:
+    k8s-app: netbox
+---
+### SSO ingress definitions
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/rewrite-target: /api/plugins/sso/$1
+  name: netbox-sso
+  namespace: netbox-community
+spec:
+  rules:
+  - host: netbox.company.ca #changeme
+    http:
+      paths:
+      - backend:
+          serviceName: netbox-sso
+          servicePort: 80
+        path: /sso/(.*)
+  tls:
+  - hosts:
+    - netbox.company.ca #changeme
+    secretName: netbox-tls
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/rewrite-target: /api/plugins/sso/login/$1
+  name: netbox-sso-login
+  namespace: netbox-community
+spec:
+  rules:
+  - host: netbox.company.ca #changeme
+    http:
+      paths:
+      - backend:
+          serviceName: netbox-sso-login
+          servicePort: 80
+        path: /login/(.*)
+  tls:
+  - hosts:
+    - netbox.company.ca #changeme
+    secretName: netbox-tls

--- a/startup-configmap.yaml
+++ b/startup-configmap.yaml
@@ -1,0 +1,87 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: startup-configmap
+  namespace: netbox-community
+data:
+  # NetBox plugins definition and configuration
+  netbox-plugins.py: |
+    # Enter every plugin to be enabled by NetBox
+    # Uncomment 'django3_saml2_nbplugin' if you want to enable SSO
+    PLUGINS = []
+    #PLUGINS = ['django3_saml2_nbplugin']
+    # NetBox plugins configuration definition
+    PLUGINS_CONFIG = {
+        'django3_saml2_nbplugin': {
+
+            # Use the Netbox default remote backend
+            # 'AUTHENTICATION_BACKEND': 'netbox.authentication.RemoteUserBackend',
+            'AUTHENTICATION_BACKEND': 'django3_saml2_nbplugin.backends.SAML2CustomAttrUserBackend',
+            # 'AUTHENTICATION_BACKEND': 'django3_saml2_nbplugin.backends.SAML2AttrUserBackend',
+
+            # Custom URL to validate incoming SAML requests against
+            'ASSERTION_URL': 'https://netbox.company.ca', #changeme
+
+            # Populates the Issuer element in authn reques e.g defined as "Audience URI (SP Entity ID)" in SSO
+            'ENTITY_ID': 'https://netbox.company.ca', #changeme
+
+            # # The next URL used to redirect the User after login is successful
+            'DEFAULT_NEXT_URL': '/',
+
+            # # The URL to be used for SSO sign-in purposes
+            # 'DEFAULT_SSO_ACS_URL': '/sso/acs/',
+
+            # Metadata is required, choose either remote url
+            #'METADATA_AUTO_CONF_URL': "https://mycorp.okta.com/appd/sajfalkdsflkads/sso/saml/metadata",
+            # or local file path
+            'METADATA_LOCAL_FILE_PATH': '/opt/netbox/sso-saml2.xml',
+
+            # Settings for SAML2CustomAttrUserBackend. Optional.
+            'CUSTOM_ATTR_BACKEND': {
+                # Attribute containing the username. Optional.
+                'USERNAME_ATTR': 'user_name',
+                # Attribute containing the user's email. Optional.
+                'MAIL_ATTR': 'email',
+                # Attribute containing the user's first name. Optional.
+                'FIRST_NAME_ATTR': 'first_name',
+                # Attribute containing the user's last name. Optional.
+                'LAST_NAME_ATTR': 'last_name',
+                # Set to True to always update the user on logon
+                # from SAML attributes on logon. Defaults to False.
+                'ALWAYS_UPDATE_USER': True,
+                # Attribute that contains groups. Optional.
+                'GROUP_ATTR': 'memberOf',
+                # Dict of user flags to groups.
+                # If the user is in the group then the flag will be set to True. Optional.
+                # Used as an override to the same variable set in ldap_config.py in netbox-configmap. It is commented out since it is unnecessary to have the already set configurations overrided.
+                #'FLAGS_BY_GROUP': {
+                #    'is_active': 'SSO_ACTIVE_GROUP',
+                #    'is_staff': 'SSO_STAFF_GROUP',
+                #    'is_superuser': 'SSO_SUPERUSER_GROUP'
+                #},
+                # Dict of SAML groups to NetBox groups. Optional.
+                # Groups must be created beforehand in NetBox.
+                # Used to populate NetBox defined user groups (right) with members of groups in the SSO source (left). Not necessary if NetBox groups and members are already defined in the SSO source
+                #'GROUP_MAPPINGS': {
+                #     'SSO_GROUP1': 'LOCAL_NETBOX_GROUP1',
+                #     'SSO_GROUP2': 'LOCAL_NETBOX_GROUP2'
+                #}
+            }
+        }
+    }
+
+  # Script for installing NetBox plugins packages
+  install-plugins.sh: |
+    source /opt/netbox/venv/bin/activate
+    # SSO implementation plugin packages
+    apk add xmlsec
+    pip install django3_auth_saml2
+    pip install netbox-plugin-auth-saml2
+
+  # Script for starting rqworker, which handles reports
+  start-rqworker.sh: |
+    /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py rqworker &>/dev/null &disown;
+
+  # Script for fixing permission issue in unit temporary folder
+  nginx-caching-fix.sh: |
+    chown unit:root -R /opt/unit/tmp/


### PR DESCRIPTION
The purpose of this pull request is for the following
- Updating NetBox to v2.11.12, including necessary configuration changes
- Adding optional SSO authentication to NetBox through SSO plugins django3_auth_saml2 and netbox-plugin-auth-saml2
- Updating postresql and redis pods to more up-to-date versions (stable/redis and stable/postgresql were deprecated in favor of bitnami/redis and bitnami/postgresql)
- Removing nginx sidecar as it is no longer required in the current version
- Fix issue with uploading images and other large requests due to a 'unit' permission issue arising from NetBox pods being instantiated by root in Kubernetes
- Fix the REDIS_CACHE_HOST env variable issue
- README.md updated to reflect changes